### PR TITLE
Reconcile Gslb when relevant Endpoint is updated

### DIFF
--- a/pkg/controller/gslb/gslb_controller.go
+++ b/pkg/controller/gslb/gslb_controller.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	ohmyglbv1beta1 "github.com/AbsaOSS/ohmyglb/pkg/apis/ohmyglb/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	types "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -53,6 +55,44 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		IsController: true,
 		OwnerType:    &ohmyglbv1beta1.Gslb{},
 	})
+	if err != nil {
+		return err
+	}
+
+	// Figure out Gslb resource name to Reconcile when non controlled Endpoint is updated
+	mapFn := handler.ToRequestsFunc(
+		func(a handler.MapObject) []reconcile.Request {
+			gslbList := &ohmyglbv1beta1.GslbList{}
+			opts := []client.ListOption{
+				client.InNamespace(a.Meta.GetNamespace()),
+			}
+			c := mgr.GetClient()
+			c.List(context.TODO(), gslbList, opts...)
+			gslbName := ""
+			for _, gslb := range gslbList.Items {
+				for _, rule := range gslb.Spec.Ingress.Rules {
+					for _, path := range rule.HTTP.Paths {
+						if path.Backend.ServiceName == a.Meta.GetName() {
+							gslbName = gslb.Name
+						}
+					}
+				}
+			}
+			return []reconcile.Request{
+				{NamespacedName: types.NamespacedName{
+					Name:      gslbName,
+					Namespace: a.Meta.GetNamespace(),
+				}},
+			}
+		})
+
+	// Watch for Endpoints that are not controlled directly
+	err = c.Watch(
+		&source.Kind{Type: &corev1.Endpoints{}},
+		&handler.EnqueueRequestsFromMapFunc{
+			ToRequests: mapFn,
+		},
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* We care about Endpoint(and eventually Service) status
* We do not control Endpoints/Service directly by operator
* The only link in `serviceName` inside of inline Ingress spec of Gslb
* Thus we create a `Watch` over Endpoint and dynamically match Gslbs to
  reconcile searching for associated `serviceName` which explicitly matches
`Service` and `Endpoint` names