### PR TITLE
Prototype of external-dns + coredns based configuration

### DIFF
--- a/deploy/coredns/README.md
+++ b/deploy/coredns/README.md
@@ -1,7 +1,8 @@
-# CoreDNS helm install to act as resolver for GSLB
+# Ingress controller, etcd-operator, CoreDNS helm install
 
+Here we are installing resources which are working in tandem but not directly managed by OhMyGLB operator
 
-### Baremetal nginx-controller setup
+### Baremetal(or local Minukube/Kind cluster) nginx-controller setup
 ```
 helm -n ohmyglb upgrade -i nginx-ingress stable/nginx-ingress --set controller.service.type=NodePort --set controller.reportNodeInternalIp=true --set controller.hostNetwork=true
 ```

--- a/deploy/coredns/README.md
+++ b/deploy/coredns/README.md
@@ -1,5 +1,19 @@
 # CoreDNS helm install to act as resolver for GSLB
 
+
+### Baremetal nginx-controller setup
+```
+helm -n ohmyglb upgrade -i nginx-ingress stable/nginx-ingress --set controller.service.type=NodePort --set controller.reportNodeInternalIp=true --set controller.hostNetwork=true
+```
+
+### Etcd backend for CoreDNS
+
+```
+helm -n ohmyglb upgrade -i etcd-for-coredns stable/etcd-operator --set customResources.createEtcdClusterCRD=true
+```
+
+### CoreDNS itself
+
 ```
 helm -n ohmyglb upgrade -i gslb-coredns stable/coredns -f values.yaml
 ```

--- a/deploy/coredns/dns-endpoint-crd-manifest.yaml
+++ b/deploy/coredns/dns-endpoint-crd-manifest.yaml
@@ -1,0 +1,66 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    api: externaldns
+    kubebuilder.k8s.io: 1.0.0
+  name: dnsendpoints.externaldns.k8s.io
+spec:
+  group: externaldns.k8s.io
+  names:
+    kind: DNSEndpoint
+    plural: dnsendpoints
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            endpoints:
+              items:
+                properties:
+                  dnsName:
+                    type: string
+                  labels:
+                    type: object
+                  providerSpecific:
+                    items:
+                      properties:
+                        name: 
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  recordTTL:
+                    format: int64
+                    type: integer
+                  recordType:
+                    type: string
+                  targets:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/coredns/dnsendpoint-example.yaml
+++ b/deploy/coredns/dnsendpoint-example.yaml
@@ -1,0 +1,11 @@
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: examplednsrecord
+spec:
+  endpoints:
+  - dnsName: foo.absa.external
+    recordTTL: 180
+    recordType: A
+    targets:
+    - 10.1.1.1

--- a/deploy/coredns/external-dns.yaml
+++ b/deploy/coredns/external-dns.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions"]
+  resources: ["ingresses"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: ohmyglb
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: ohmyglb
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: ohmyglb
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        args:
+        - --source=ingress
+        - --provider=coredns
+        - --log-level=debug # debug only
+        - --annotation-filter=ohmyglb.absa.oss/healthy=true
+        env:
+        - name: ETCD_URLS
+          value: http://etcd-cluster-client:2379

--- a/deploy/coredns/external-dns.yaml
+++ b/deploy/coredns/external-dns.yaml
@@ -16,6 +16,12 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["list"]
+- apiGroups: ["externaldns.k8s.io"]
+  resources: ["dnsendpoints"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["externaldns.k8s.io"]
+  resources: ["dnsendpoints/status"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -57,10 +63,9 @@ spec:
       - name: external-dns
         image: registry.opensource.zalan.do/teapot/external-dns:latest
         args:
-        - --source=ingress
+        - --source=crd
         - --provider=coredns
         - --log-level=debug # debug only
-        - --annotation-filter=ohmyglb.absa.oss/healthy=true
         env:
         - name: ETCD_URLS
           value: http://etcd-cluster-client:2379

--- a/deploy/coredns/values.yaml
+++ b/deploy/coredns/values.yaml
@@ -76,11 +76,12 @@ servers:
     parameters: 0.0.0.0:9153
   - name: forward
     parameters: . /etc/resolv.conf
-  - name: hosts
-    parameters: /etc/coredns/gslb.hosts
+  - name: etcd
+    parameters: absa.external
     configBlock: |-
-      ttl 30
-      reload "300ms"
+      stubzones
+      path /skydns
+      endpoint http://etcd-cluster-client:2379
 
 # Complete example with all the options:
 # - zones:                 # the `zones` block can be left out entirely, defaults to "."

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -ex
+
+application_order="namespace.yaml
+role.yaml
+role_binding.yaml
+service_account.yaml
+operator.yaml"
+
+for file in $application_order
+do
+    kubectl apply -f "$file"
+done

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 kind: Namespace
 metadata:
   name: ohmyglb


### PR DESCRIPTION
* Use external-dns to populate coreDNS conf with etcd backend
  Based on https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/coredns.md
* Use `--annotation-filter` to figure out health status

Visible limitaitons:
* coreDNS etcd plugin can support only single authoritative zone
* Annotation status is global to Ingress, so all `host` entries affected
  It might imply single `host` entry per Gslb requirement

Runtime example:

* External-dns logs
```
time="2019-12-23T14:50:29Z" level=debug msg="Endpoints generated from ingress: default/example-gslb: [app.cloud.absa.internal 0 IN A 172.17.0.2 [] app1.cloud.absa.external 0 IN A 172.17.0.2 [] app2.cloud.absa.external 0 IN A 172.17.0.2 []
```
* Query test
```
dnstools# dig @gslb-coredns-coredns app1.cloud.absa.external +short
172.17.0.2
```
```
dnstools# dig @gslb-coredns-coredns SOA app1.cloud.absa.external +short
ns.dns.absa.external. hostmaster.absa.external. 1577113239 7200 1800 86400 30
```
So coredns etcd plugin(skyDNS) can serve single authoritative zone

Apart from above mentioned limitations this setup has advantages of
being very dynamic and decoupled from ohmyglb controller implementation.

On ohmyglb side we can control dns record population through annotations
instead of direct writes to coreDNS configmap