### PR TITLE
Dynamically populate DNSEndpoints according to health status 

### DIFF
--- a/deploy/crds/ohmyglb.absa.oss_v1beta1_gslb_cr.yaml
+++ b/deploy/crds/ohmyglb.absa.oss_v1beta1_gslb_cr.yaml
@@ -1,7 +1,8 @@
 apiVersion: ohmyglb.absa.oss/v1beta1
 kind: Gslb
 metadata:
-  name: example-gslb
+  name: test-gslb
+  namespace: test-gslb
 spec:
   ingress:
     rules:
@@ -12,14 +13,14 @@ spec:
                 serviceName: app
                 servicePort: http
               path: /
-      - host: app1.cloud.absa.external
+      - host: app2.cloud.absa.internal
         http:
           paths:
           - backend:
               serviceName: unhealthy-nginx
               servicePort: http
             path: /
-      - host: app2.cloud.absa.external
+      - host: app3.cloud.absa.internal
         http:
           paths:
           - backend:

--- a/pkg/controller/gslb/dnsupdate.go
+++ b/pkg/controller/gslb/dnsupdate.go
@@ -155,9 +155,9 @@ func (r *ReconcileGslb) ensureDNSEndpoint(request reconcile.Request,
 }
 
 func prettyPrint(s interface{}) string {
-	pretty_s, err := json.MarshalIndent(s, "", "\t")
+	prettyStruct, err := json.MarshalIndent(s, "", "\t")
 	if err != nil {
 		fmt.Println("can't convert struct to json")
 	}
-	return string(pretty_s)
+	return string(prettyStruct)
 }

--- a/pkg/controller/gslb/dnsupdate.go
+++ b/pkg/controller/gslb/dnsupdate.go
@@ -149,7 +149,13 @@ func (r *ReconcileGslb) ensureDNSEndpoint(request reconcile.Request,
 
 	// Update existing object with new spec
 	found.Spec = i.Spec
-	r.client.Update(context.TODO(), found)
+	err = r.client.Update(context.TODO(), found)
+
+	if err != nil {
+		// Update failed
+		log.Error(err, "Failed to update DNSEndpoint", "DNSEndpoint.Namespace", found.Namespace, "DNSEndpoint.Name", found.Name)
+		return &reconcile.Result{}, err
+	}
 
 	return nil, nil
 }

--- a/pkg/controller/gslb/gslb_controller_test.go
+++ b/pkg/controller/gslb/gslb_controller_test.go
@@ -3,7 +3,6 @@ package gslb
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"reflect"
 	"regexp"
@@ -325,7 +324,7 @@ func TestGslbController(t *testing.T) {
 		got := dnsEndpoint.Spec.Endpoints
 
 		want := []*externaldns.Endpoint{{
-			DNSName:    "app3.absa.cloud.internal",
+			DNSName:    "app3.cloud.absa.internal",
 			RecordTTL:  30,
 			RecordType: "A",
 			Targets:    externaldns.Targets{"10.0.0.1"}},
@@ -393,12 +392,4 @@ func yamlToConfigMap(yaml []byte) (*corev1.ConfigMap, error) {
 		return &corev1.ConfigMap{}, err
 	}
 	return cm, nil
-}
-
-func prettyPrint(s interface{}) string {
-	pretty_s, err := json.MarshalIndent(s, "", "\t")
-	if err != nil {
-		fmt.Println("can't convert struct to json")
-	}
-	return string(pretty_s)
 }

--- a/pkg/controller/gslb/gslb_controller_test.go
+++ b/pkg/controller/gslb/gslb_controller_test.go
@@ -3,6 +3,7 @@ package gslb
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"reflect"
 	"regexp"
@@ -321,20 +322,20 @@ func TestGslbController(t *testing.T) {
 			t.Fatalf("Failed to get expected DNSEndpoint: (%v)", err)
 		}
 
-		got := dnsEndpoint
+		got := dnsEndpoint.Spec.Endpoints
 
-		want := &externaldns.DNSEndpoint{
-			Spec: externaldns.DNSEndpointSpec{
-				Endpoints: []*externaldns.Endpoint{{
-					DNSName:    "app3.absa.cloud.internal",
-					RecordTTL:  30,
-					RecordType: "A",
-					Targets:    externaldns.Targets{"10.0.0.1"}},
-				},
-			},
+		want := []*externaldns.Endpoint{{
+			DNSName:    "app3.absa.cloud.internal",
+			RecordTTL:  30,
+			RecordType: "A",
+			Targets:    externaldns.Targets{"10.0.0.1"}},
 		}
+
+		prettyGot := prettyPrint(got)
+		prettyWant := prettyPrint(want)
+
 		if !reflect.DeepEqual(got, want) {
-			t.Errorf("want %v DNSEndpoint, got %v", want, got)
+			t.Errorf("got:\n %s DNSEndpoint,\n\n want:\n %s", prettyGot, prettyWant)
 		}
 	})
 }
@@ -392,4 +393,12 @@ func yamlToConfigMap(yaml []byte) (*corev1.ConfigMap, error) {
 		return &corev1.ConfigMap{}, err
 	}
 	return cm, nil
+}
+
+func prettyPrint(s interface{}) string {
+	pretty_s, err := json.MarshalIndent(s, "", "\t")
+	if err != nil {
+		fmt.Println("can't convert struct to json")
+	}
+	return string(pretty_s)
 }

--- a/pkg/controller/gslb/gslb_controller_test.go
+++ b/pkg/controller/gslb/gslb_controller_test.go
@@ -3,6 +3,7 @@ package gslb
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
 	"reflect"
 	"regexp"
 	"testing"
@@ -23,39 +24,6 @@ import (
 	zap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-var gslbYaml = []byte(`
-apiVersion: ohmyglb.absa.oss/v1beta1
-kind: Gslb
-metadata:
-  name: test-gslb
-  namespace: test-gslb
-spec:
-  ingress:
-    rules:
-    - host: app.cloud.absa.internal
-      http:
-        paths:
-        - backend:
-            serviceName: app
-            servicePort: http
-          path: /
-    - host: app1.cloud.absa.external
-      http:
-        paths:
-        - backend:
-            serviceName: unhealthy-nginx
-            servicePort: http
-          path: /
-    - host: app2.cloud.absa.external
-      http:
-        paths:
-        - backend:
-            serviceName: healthy-nginx
-            servicePort: http
-          path: /
-  strategy: roundRobin
-`)
 
 var corednsConfigMapYaml = []byte(`
 apiVersion: v1
@@ -87,12 +55,16 @@ metadata:
   namespace: ohmyglb
 `)
 
+var crSampleYaml = "../../../deploy/crds/ohmyglb.absa.oss_v1beta1_gslb_cr.yaml"
+
 func TestGslbController(t *testing.T) {
+	gslbYaml, err := ioutil.ReadFile(crSampleYaml)
+	if err != nil {
+		t.Fatalf("Can't open example CR file: %s", crSampleYaml)
+	}
 	// Set the logger to development mode for verbose logs.
 	logf.SetLogger(zap.Logger(true))
 
-	gslbName := "test-gslb"
-	namespace := "test-gslb"
 	cmName := "gslb-coredns-coredns"
 
 	gslb, err := yamlToGslb(gslbYaml)
@@ -124,8 +96,8 @@ func TestGslbController(t *testing.T) {
 	// watched resource .
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
-			Name:      gslbName,
-			Namespace: namespace,
+			Name:      gslb.Name,
+			Namespace: gslb.Namespace,
 		},
 	}
 
@@ -159,7 +131,7 @@ func TestGslbController(t *testing.T) {
 			t.Fatalf("Failed to get expected gslb: (%v)", err)
 		}
 
-		expectedHosts := []string{"app.cloud.absa.internal", "app1.cloud.absa.external", "app2.cloud.absa.external"}
+		expectedHosts := []string{"app.cloud.absa.internal", "app2.cloud.absa.internal", "app3.cloud.absa.internal"}
 		actualHosts := gslb.Status.ManagedHosts
 		if !reflect.DeepEqual(expectedHosts, actualHosts) {
 			t.Errorf("expected %v managed hosts, but got %v", expectedHosts, actualHosts)
@@ -177,11 +149,11 @@ func TestGslbController(t *testing.T) {
 
 	t.Run("Unhealthy service status", func(t *testing.T) {
 		serviceName := "unhealthy-nginx"
-		unhealthyHost := "app1.cloud.absa.external"
+		unhealthyHost := "app2.cloud.absa.internal"
 		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
-				Namespace: namespace,
+				Namespace: gslb.Namespace,
 			},
 		}
 
@@ -193,7 +165,7 @@ func TestGslbController(t *testing.T) {
 		endpoint := &corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
-				Namespace: namespace,
+				Namespace: gslb.Namespace,
 			},
 		}
 
@@ -217,7 +189,7 @@ func TestGslbController(t *testing.T) {
 		service := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
-				Namespace: namespace,
+				Namespace: gslb.Namespace,
 				Labels:    labels,
 			},
 		}
@@ -231,7 +203,7 @@ func TestGslbController(t *testing.T) {
 		endpoint := &corev1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
-				Namespace: namespace,
+				Namespace: gslb.Namespace,
 				Labels:    labels,
 			},
 			Subsets: []corev1.EndpointSubset{
@@ -249,7 +221,7 @@ func TestGslbController(t *testing.T) {
 		reconcileAndUpdateGslb(t, r, req, cl, gslb)
 
 		expectedServiceStatus := "Healthy"
-		healthyHost := "app2.cloud.absa.external"
+		healthyHost := "app3.cloud.absa.internal"
 		actualServiceStatus := gslb.Status.ServiceHealth[healthyHost]
 		if expectedServiceStatus != actualServiceStatus {
 			t.Errorf("expected %s service status to be %s, but got %s", healthyHost, expectedServiceStatus, actualServiceStatus)
@@ -262,7 +234,7 @@ func TestGslbController(t *testing.T) {
 		nodeLabels := map[string]string{"node-role.kubernetes.io/worker": ""}
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
+				Namespace: gslb.Namespace,
 				Name:      nodeName,
 				Labels:    nodeLabels,
 			},
@@ -307,7 +279,7 @@ func TestGslbController(t *testing.T) {
 			t.Fatalf("Failed to get expected corednsConfigMap: (%v)", err)
 		}
 
-		want := `10\.0\.0\.1.*app2.cloud.absa.external`
+		want := `10\.0\.0\.1.*app3.cloud.absa.internal`
 		got := corednsConfigMap.Data["gslb.hosts"]
 		matched, _ := regexp.MatchString(want, got)
 		if !matched {
@@ -329,7 +301,7 @@ func TestGslbController(t *testing.T) {
 			t.Fatalf("Failed to get expected corednsConfigMap: (%v)", err)
 		}
 
-		wants := []string{`10\.0\.0\.1.*app.cloud.absa.internal`, `10\.0\.0\.1.*app1.cloud.absa.external`}
+		wants := []string{`10\.0\.0\.1.*app.cloud.absa.internal`, `10\.0\.0\.1.*app2.cloud.absa.internal`}
 		for _, want := range wants {
 			got := corednsConfigMap.Data["gslb.hosts"]
 			matched, _ := regexp.MatchString(want, got)
@@ -347,6 +319,22 @@ func TestGslbController(t *testing.T) {
 		err = cl.Get(context.TODO(), req.NamespacedName, dnsEndpoint)
 		if err != nil {
 			t.Fatalf("Failed to get expected DNSEndpoint: (%v)", err)
+		}
+
+		got := dnsEndpoint
+
+		want := &externaldns.DNSEndpoint{
+			Spec: externaldns.DNSEndpointSpec{
+				Endpoints: []*externaldns.Endpoint{{
+					DNSName:    "app3.absa.cloud.internal",
+					RecordTTL:  30,
+					RecordType: "A",
+					Targets:    externaldns.Targets{"10.0.0.1"}},
+				},
+			},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("want %v DNSEndpoint, got %v", want, got)
 		}
 	})
 }

--- a/pkg/controller/gslb/ingress.go
+++ b/pkg/controller/gslb/ingress.go
@@ -56,5 +56,9 @@ func (r *ReconcileGslb) ensureIngress(request reconcile.Request,
 		return &reconcile.Result{}, err
 	}
 
+	// Update existing object with new spec
+	found.Spec = i.Spec
+	r.client.Update(context.TODO(), found)
+
 	return nil, nil
 }

--- a/pkg/controller/gslb/ingress.go
+++ b/pkg/controller/gslb/ingress.go
@@ -58,7 +58,13 @@ func (r *ReconcileGslb) ensureIngress(request reconcile.Request,
 
 	// Update existing object with new spec
 	found.Spec = i.Spec
-	r.client.Update(context.TODO(), found)
+	err = r.client.Update(context.TODO(), found)
+
+	if err != nil {
+		// Update failed
+		log.Error(err, "Failed to update Ingress", "Ingress.Namespace", found.Namespace, "Ingress.Name", found.Name)
+		return &reconcile.Result{}, err
+	}
 
 	return nil, nil
 }


### PR DESCRIPTION
* Populate DNSEndpoint spec with Healthy only endpoints
* Inline Ingress update fix so gslb will update child Ingress spec
  with react to the own spec changes
* Associated tests and pretty struct printing for clear logging in
  the tests and in general