### PR TITLE
Switch source of addresses for A records to Ingress

### DIFF
--- a/deploy/coredns/values.yaml
+++ b/deploy/coredns/values.yaml
@@ -77,7 +77,7 @@ servers:
   - name: forward
     parameters: . /etc/resolv.conf
   - name: etcd
-    parameters: absa.external
+    parameters: absa.internal
     configBlock: |-
       stubzones
       path /skydns

--- a/pkg/controller/gslb/gslb_controller_test.go
+++ b/pkg/controller/gslb/gslb_controller_test.go
@@ -313,6 +313,15 @@ func TestGslbController(t *testing.T) {
 
 	t.Run("Gslb creates DNSEndpoint CR for healthy ingress hosts", func(t *testing.T) {
 
+		ingressIP := corev1.LoadBalancerIngress{
+			IP: "10.0.0.1",
+		}
+		ingress.Status.LoadBalancer.Ingress = append(ingress.Status.LoadBalancer.Ingress, ingressIP)
+		err := cl.Status().Update(context.TODO(), ingress)
+		if err != nil {
+			t.Fatalf("Failed to update gslb Ingress Address: (%v)", err)
+		}
+
 		reconcileAndUpdateGslb(t, r, req, cl, gslb)
 
 		dnsEndpoint := &externaldns.DNSEndpoint{}


### PR DESCRIPTION
* Instead of manually resolve worker healthiness use information
  from Ingress status:
```
$ k get ing
NAME        HOSTS                                                                           ADDRESS      PORTS   AGE
test-gslb   app.cloud.absa.internal,app2.cloud.absa.internal,app3.cloud.absa.internal   172.17.0.2   80      18h
```
* Assuming properly configured Ingress controller Address in status
should be always populated
* Ingress Address can be either worker nodes or load balancer depending
on specific cluster and ingress controller configuration so we properly
abstract it