### PR TITLE
BUGFIX: populate record status only when it's ready

### DIFF
--- a/chart/ohmyglb/Chart.yaml
+++ b/chart/ohmyglb/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.2.2
+appVersion: 0.2.3
 
 dependencies:
   - name: etcd-operator

--- a/chart/ohmyglb/values.yaml
+++ b/chart/ohmyglb/values.yaml
@@ -6,7 +6,7 @@ global:
   # - name: "image-pull-secret"
 
 ohmyglb:
-  image: ytsarev/ohmyglb:v0.2.2
+  image: ytsarev/ohmyglb:v0.2.3
   ingressNamespace: "ohmyglb"
   dnsZone: &dnsZone "example.com"
 

--- a/pkg/controller/gslb/status.go
+++ b/pkg/controller/gslb/status.go
@@ -119,7 +119,9 @@ func (r *ReconcileGslb) getHealthyRecords(gslb *ohmyglbv1beta1.Gslb) (map[string
 	for _, host := range healthyHosts {
 		for _, endpoint := range dnsEndpoint.Spec.Endpoints {
 			if endpoint.DNSName == host {
-				healthyRecords[host] = endpoint.Targets
+				if len(endpoint.Targets) > 0 {
+					healthyRecords[host] = endpoint.Targets
+				}
 			}
 		}
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.2.2"
+	Version = "0.2.3"
 )


### PR DESCRIPTION
Avoid error in reconciliation logs similar to
```
status.healthyRecords.app3.cloud.example.com in body must be of type array: \"null\"
```

Until related DNSEndpoint is Ready the Status will properly look like
```
healthyRecords: {}
```