### PR TITLE
External dns ownership fix

### DIFF
--- a/chart/ohmyglb/templates/external-dns/external-dns.yaml
+++ b/chart/ohmyglb/templates/external-dns/external-dns.yaml
@@ -67,6 +67,7 @@ spec:
         - --source=crd
         - --provider=coredns
         - --log-level=debug # debug only
+        - --txt-owner-id="ohmyglb"
         env:
         - name: ETCD_URLS
           value: http://etcd-cluster-client:2379

--- a/chart/ohmyglb/values.yaml
+++ b/chart/ohmyglb/values.yaml
@@ -12,7 +12,7 @@ ohmyglb:
   extGslbClusters: "" # comma-separated list of FQDNs pointing to external Gslb enabled clusters to work with
 
 externaldns:
-  image: registry.opensource.zalan.do/teapot/external-dns:latest
+  image: eu.gcr.io/k8s-artifacts-prod/external-dns/external-dns:v0.5.18
 
 etcd-operator:
   customResources:

--- a/pkg/controller/gslb/gslb_controller_test.go
+++ b/pkg/controller/gslb/gslb_controller_test.go
@@ -191,10 +191,14 @@ func TestGslbController(t *testing.T) {
 
 	t.Run("Gslb creates DNSEndpoint CR for healthy ingress hosts", func(t *testing.T) {
 
-		ingressIP := corev1.LoadBalancerIngress{
-			IP: "10.0.0.1",
+		ingressIPs := []corev1.LoadBalancerIngress{
+			{IP: "10.0.0.1"},
+			{IP: "10.0.0.2"},
+			{IP: "10.0.0.3"},
 		}
-		ingress.Status.LoadBalancer.Ingress = append(ingress.Status.LoadBalancer.Ingress, ingressIP)
+
+		ingress.Status.LoadBalancer.Ingress = append(ingress.Status.LoadBalancer.Ingress, ingressIPs...)
+
 		err := cl.Status().Update(context.TODO(), ingress)
 		if err != nil {
 			t.Fatalf("Failed to update gslb Ingress Address: (%v)", err)
@@ -215,12 +219,12 @@ func TestGslbController(t *testing.T) {
 				DNSName:    "localtargets.app3.cloud.example.com",
 				RecordTTL:  30,
 				RecordType: "A",
-				Targets:    externaldns.Targets{"10.0.0.1"}},
+				Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"}},
 			{
 				DNSName:    "app3.cloud.example.com",
 				RecordTTL:  30,
 				RecordType: "A",
-				Targets:    externaldns.Targets{"10.0.0.1"}},
+				Targets:    externaldns.Targets{"10.0.0.1", "10.0.0.2", "10.0.0.3"}},
 		}
 
 		prettyGot := prettyPrint(got)
@@ -236,7 +240,7 @@ func TestGslbController(t *testing.T) {
 	// code so I will keep it this way for a time being
 	t.Run("DNS Record reflection in status", func(t *testing.T) {
 		got := gslb.Status.HealthyRecords
-		want := map[string][]string{"app3.cloud.example.com": {"10.0.0.1"}}
+		want := map[string][]string{"app3.cloud.example.com": {"10.0.0.1", "10.0.0.2", "10.0.0.3"}}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got:\n %s healthyRecords status,\n\n want:\n %s", got, want)
 		}


### PR DESCRIPTION
We faced ` [] because owner id does not match, found: \"\", required: \"default\""`
during updates of gslb controlled dns entries.
To fix that:
* Update to latest 5.18 external-dns release
* Explicitly set `txt-ownership-id` to avoid mismatch