### PR TITLE
Enable periodic reconciliation

### DIFF
--- a/chart/ohmyglb/Chart.yaml
+++ b/chart/ohmyglb/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.3.1
+appVersion: 0.3.2
 
 dependencies:
   - name: etcd-operator

--- a/chart/ohmyglb/values.yaml
+++ b/chart/ohmyglb/values.yaml
@@ -6,7 +6,7 @@ global:
   # - name: "image-pull-secret"
 
 ohmyglb:
-  image: ytsarev/ohmyglb:v0.3.1
+  image: ytsarev/ohmyglb:v0.3.2
   ingressNamespace: "ohmyglb"
   dnsZone: &dnsZone "example.com"
   extGslbClusters: "" # comma-separated list of FQDNs pointing to external Gslb enabled clusters to work with

--- a/pkg/controller/gslb/gslb_controller.go
+++ b/pkg/controller/gslb/gslb_controller.go
@@ -2,6 +2,7 @@ package gslb
 
 import (
 	"context"
+	"time"
 
 	ohmyglbv1beta1 "github.com/AbsaOSS/ohmyglb/pkg/apis/ohmyglb/v1beta1"
 	externaldns "github.com/kubernetes-incubator/external-dns/endpoint"
@@ -191,6 +192,8 @@ func (r *ReconcileGslb) Reconcile(request reconcile.Request) (reconcile.Result, 
 	}
 
 	// == Finish ==========
-	// Everything went fine, don't requeue
-	return reconcile.Result{}, nil
+	// Everything went fine, requeue after some time to catch up
+	// with external Gslb status
+	// TODO: potentially enhance with smarter reaction to external Event
+	return reconcile.Result{RequeueAfter: time.Second * 30}, nil
 }

--- a/pkg/controller/gslb/gslb_controller_test.go
+++ b/pkg/controller/gslb/gslb_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	ohmyglbv1beta1 "github.com/AbsaOSS/ohmyglb/pkg/apis/ohmyglb/v1beta1"
 	externaldns "github.com/kubernetes-incubator/external-dns/endpoint"
@@ -81,13 +82,7 @@ func TestGslbController(t *testing.T) {
 
 	// Reconcile again so Reconcile() checks services and updates the Gslb
 	// resources' Status.
-	res, err = r.Reconcile(req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-	if res != (reconcile.Result{}) {
-		t.Error("reconcile did not return an empty Result")
-	}
+	reconcileAndUpdateGslb(t, r, req, cl, gslb)
 
 	t.Run("ManagedHosts status", func(t *testing.T) {
 		err = cl.Get(context.TODO(), req.NamespacedName, gslb)
@@ -260,8 +255,8 @@ func reconcileAndUpdateGslb(t *testing.T,
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	if res != (reconcile.Result{}) {
-		t.Error("reconcile did not return an empty Result")
+	if res != (reconcile.Result{RequeueAfter: time.Second * 30}) {
+		t.Error("reconcile did not return Result with Requeue")
 	}
 
 	err = cl.Get(context.TODO(), req.NamespacedName, gslb)

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.3.1"
+	Version = "0.3.2"
 )


### PR DESCRIPTION
Requeu Reconcile after successful run
to be able to track external Gslb status (`localtargets.*`)

It is tentative solution, ideally we find some more
elegant way to keep up with external status