### PR TITLE
Multi node local kind cluster

### DIFF
--- a/deploy/ingress/nginx-ingress-values.yaml
+++ b/deploy/ingress/nginx-ingress-values.yaml
@@ -116,7 +116,7 @@ controller:
 
   ## DaemonSet or Deployment
   ##
-  kind: Deployment
+  kind: DaemonSet
 
   ## Annotations to be added to the controller deployment
   ##

--- a/deploy/kind/cluster.yaml
+++ b/deploy/kind/cluster.yaml
@@ -2,14 +2,9 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  kubeadmConfigPatches:
-  - |
-    apiVersion: kubeadm.k8s.io/v1beta2
-    kind: InitConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        node-labels: "ingress-ready=true"
-        authorization-mode: "AlwaysAllow"
+- role: worker
+- role: worker
+- role: worker
   extraPortMappings:
   - containerPort: 80
     hostPort: 80


### PR DESCRIPTION
More realistic local deployment:

* 3 workers
* nginx-ingress as DaemonSet(similar to Rancher style deployment)
* Convenient to investigate/debug DNSEnpoints as we have now multiple
  records in local scenario, e.g.
```
    - dnsName: app3.cloud.example.com
      recordTTL: 30
      recordType: A
      targets:
      - 172.17.0.2
      - 172.17.0.4
      - 172.17.0.5
```