### PR TITLE
Quote geo tag declaration

### DIFF
--- a/chart/ohmyglb/templates/operator.yaml
+++ b/chart/ohmyglb/templates/operator.yaml
@@ -32,7 +32,7 @@ spec:
             - name: EXT_GSLB_CLUSTERS
               value: {{ .Values.ohmyglb.extGslbClusters }}
             - name: CLUSTER_GEO_TAG
-              value: {{ .Values.ohmyglb.clusterGeoTag }}
+              value: {{ quote .Values.ohmyglb.clusterGeoTag }}
             - name: EDGE_DNS_ZONE
               value: {{ .Values.ohmyglb.edgeDNSZone }}
             - name: DNS_ZONE


### PR DESCRIPTION
* If geo tag is digit only, e.g. "123", the config map creation/patch
  freaks out
* Use `quote` helm template function to fix it