### PR TITLE
Config and helpers for local multicluster setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,22 @@ dns-smoke-test:
 
 .PHONY: deploy-local-cluster
 deploy-local-cluster:
-	kind create cluster --config=deploy/kind/cluster.yaml
+	kind create cluster --config=deploy/kind/cluster.yaml --name test-gslb1
+
+.PHONY: deploy-local-multi-cluster-setup
+deploy-local-multi-cluster-setup:
+	kind create cluster --config=deploy/kind/cluster.yaml --name test-gslb1
+	kind create cluster --config=deploy/kind/cluster2.yaml --name test-gslb2
+
 
 .PHONY: destroy-local-cluster
 destroy-local-cluster:
-	kind delete cluster
+	kind delete cluster --name test-gslb1
+
+.PHONY: destroy-local-multi-cluster-setup
+destroy-local-multi-cluster-setup:
+	kind delete cluster --name test-gslb1
+	kind delete cluster --name test-gslb2
 
 .PHONY: create-ohmyglb-ns
 create-ohmyglb-ns:

--- a/chart/ohmyglb/templates/operator.yaml
+++ b/chart/ohmyglb/templates/operator.yaml
@@ -13,6 +13,12 @@ spec:
       labels:
         name: ohmyglb
     spec:
+      {{ if .Values.ohmyglb.hostAlias.enabled }}
+      hostAliases:
+        - ip: "{{ .Values.ohmyglb.hostAlias.ip }}"
+          hostnames:
+          - "{{ .Values.ohmyglb.hostAlias.hostname }}"
+      {{ end }}
       serviceAccountName: ohmyglb
       containers:
         - name: ohmyglb

--- a/chart/ohmyglb/values.yaml
+++ b/chart/ohmyglb/values.yaml
@@ -12,6 +12,10 @@ ohmyglb:
   edgeDNSZone: &edgeDNSZone "example.com"
   clusterGeoTag: "eu" # used for places where we need to distinguish between differnet Gslb instances
   extGslbClustersGeoTags: "us" # comma-separated list of external gslb geo tags to pair with
+  hostAlias: # use https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ inside operator pod. Useful for advanced testing scenarios and to break dependency on EdgeDNS for cross ohmyglb collaboration
+    enabled: false
+    ip: "172.17.0.1"
+    hostname: "test-gslb-ns-us.example.com"
 
 externaldns:
   image: ytsarev/external-dns:v0.5.18-27-g432d0696-dirty

--- a/deploy/kind/cluster2.yaml
+++ b/deploy/kind/cluster2.yaml
@@ -1,0 +1,17 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 81
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 444
+    protocol: TCP
+  - containerPort: 53
+    hostPort: 54
+    protocol: UDP


### PR DESCRIPTION
* Make targets to create/destroy 2 local kind clusters
* hostAlias support to enable overriding of external cluster
  fqdn resolution and point to local ip address within docker network
* Enables testing ohmyglb locally with multicluster setup including
  communication between ohmyglb instances
* Especially useful to test and develop load balancing strategies
  avoiding heavy external setup