### PR TITLE
Fully automated multicluster ohmyglb local deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,10 @@ $ kubectl -n test-gslb describe gslb test-gslb
     app2.cloud.example.com:  Unhealthy
     app3.cloud.example.com:  Healthy
 ```
+
+#### Deploy full local setup
+
+To deploy two cross communicating `ohmyglb` enabled clusters with testing application on top, execute
+```
+$ make deploy-full-local-setup
+```

--- a/deploy/full.sh
+++ b/deploy/full.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Workaround of Make being to smart on up-to-date PHONY targets
+# If we execute all of them normal way, then targets from `deploy-second-ohmyglb`
+# will never be executed as they contain the same underlying target as `deploy-first-ohmyglb`
+# but with different variables
+
+make deploy-two-local-clusters use-first-context deploy-first-ohmyglb deploy-test-apps
+make use-second-context deploy-second-ohmyglb deploy-test-apps


### PR DESCRIPTION
* During documenting #62 description I realized how it
  incredibly sucks in regarding of many manual or
  semi-automated steps and very error prone
* This PR introduces fully automated setup of 2 kind clusters
  with cross-communicating ohmyglb deployments on top.
* Test apps deployment included
* Make targets are still granular and we can deploy the thing
  step by step if we want
* Useful for reproduction of complex issues like #62 and overall
  local e2e testing of features that involve cross cluster communication
* In future can be reused in e2e pipelines for environment creation
* All with single command of `$ make deploy-full-local-setup`