### PR TITLE
Set low TTL on split brain TXT record via infoblox API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 REPO ?= absaoss/ohmyglb
 VERSION ?= $$(operator-sdk up local --operator-flags=-v)
-VALUES_YAML ?= -f chart/ohmyglb/values.yaml
+VALUES_YAML ?= chart/ohmyglb/values.yaml
 HELM_ARGS ?=
 ETCD_DEBUG_IMAGE ?= quay.io/coreos/etcd:v3.2.25
 GSLB_DOMAIN ?= cloud.example.com
@@ -90,13 +90,13 @@ deploy-local-ingress: create-ohmyglb-ns
 .PHONY: deploy-gslb-operator
 deploy-gslb-operator: create-ohmyglb-ns
 	cd chart/ohmyglb && helm dependency update
-	helm -n ohmyglb upgrade -i ohmyglb chart/ohmyglb $(VALUES_YAML) $(HELM_ARGS)
+	helm -n ohmyglb upgrade -i ohmyglb chart/ohmyglb -f $(VALUES_YAML) $(HELM_ARGS)
 
 # workaround until https://github.com/crossplaneio/crossplane/issues/1170 solved
 .PHONY: deploy-gslb-operator-14
 deploy-gslb-operator-14: create-ohmyglb-ns
 	cd chart/ohmyglb && helm dependency update
-	helm -n ohmyglb template ohmyglb chart/ohmyglb $(VALUES_YAML) | kubectl -n ohmyglb --validate=false apply -f -
+	helm -n ohmyglb template ohmyglb chart/ohmyglb -f $(VALUES_YAML) | kubectl -n ohmyglb --validate=false apply -f -
 
 .PHONY: deploy-gslb-cr
 deploy-gslb-cr: create-test-ns

--- a/chart/ohmyglb/Chart.yaml
+++ b/chart/ohmyglb/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.5.3
+appVersion: 0.5.4
 
 dependencies:
   - name: etcd-operator

--- a/chart/ohmyglb/values.yaml
+++ b/chart/ohmyglb/values.yaml
@@ -6,7 +6,7 @@ global:
   # - name: "image-pull-secret"
 
 ohmyglb:
-  image: absaoss/ohmyglb:v0.5.3
+  image: absaoss/ohmyglb:v0.5.4
   ingressNamespace: "ohmyglb"
   dnsZone: &dnsZone "cloud.example.com" # dnsZone controlled by gslb
   edgeDNSZone: &edgeDNSZone "example.com" # main zone which would contain gslb zone to delegate

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/AbsaOSS/ohmyglb
 go 1.13
 
 require (
-	github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200305141429-91388c9466d8
+	github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200316164013-1a033234161e
 	github.com/ghodss/yaml v1.0.1-0.20180820084758-c7ce16629ff4
 	github.com/go-openapi/spec v0.19.0
 	github.com/kubernetes-incubator/external-dns v0.5.17

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,12 @@ github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200220151434-d103ffba14dd h1:vX
 github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200220151434-d103ffba14dd/go.mod h1:MxeaLEnYmDInNuJ7NPxN39oj0NkJGvRoPpJYCwtmnR0=
 github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200305141429-91388c9466d8 h1:TsZFZnJy98ShhkbgrAL4qk7wdzmBccBVT7N+JQlD3aI=
 github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200305141429-91388c9466d8/go.mod h1:MxeaLEnYmDInNuJ7NPxN39oj0NkJGvRoPpJYCwtmnR0=
+github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200316122153-0dd42c77df20 h1:4J4JGEaRWLLCEV7854imSsdP35B7jLo11ralT60WRFI=
+github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200316122153-0dd42c77df20/go.mod h1:MxeaLEnYmDInNuJ7NPxN39oj0NkJGvRoPpJYCwtmnR0=
+github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200316135142-508141b434e5 h1:mOMcO+TM0AY6ShAaY2a8HO/wXvjl9lCJQoCi1T3WTbo=
+github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200316135142-508141b434e5/go.mod h1:MxeaLEnYmDInNuJ7NPxN39oj0NkJGvRoPpJYCwtmnR0=
+github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200316164013-1a033234161e h1:/jgRFx+kWriaceZpXXIWyccEOcTx5lA6u6+uSbCKfbE=
+github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200316164013-1a033234161e/go.mod h1:MxeaLEnYmDInNuJ7NPxN39oj0NkJGvRoPpJYCwtmnR0=
 github.com/Azure/azure-sdk-for-go v10.0.4-beta+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v21.4.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=

--- a/pkg/controller/gslb/dnsupdate.go
+++ b/pkg/controller/gslb/dnsupdate.go
@@ -419,7 +419,7 @@ func (r *ReconcileGslb) configureZoneDelegation(gslb *ohmyglbv1beta1.Gslb) (*rec
 		}
 		if heartbeatTXTRecord == nil {
 			log.Info(fmt.Sprintf("Creating split brain TXT record(%s)...", heartbeatTXTName))
-			_, err := objMgr.CreateTXTRecord(heartbeatTXTName, edgeTimestamp, "default")
+			_, err := objMgr.CreateTXTRecord(heartbeatTXTName, edgeTimestamp, 30, "default")
 			if err != nil {
 				return &reconcile.Result{}, err
 			}

--- a/vendor/github.com/AbsaOSS/infoblox-go-client/objects.go
+++ b/vendor/github.com/AbsaOSS/infoblox-go-client/objects.go
@@ -446,6 +446,7 @@ type RecordTXT struct {
 	Ref    string `json:"_ref,omitempty"`
 	Name   string `json:"name,omitempty"`
 	Text   string `json:"text,omitempty"`
+	TTL    int    `json:"ttl,omitempty"`
 	View   string `json:"view,omitempty"`
 	Zone   string `json:"zone,omitempty"`
 	Ea     EA     `json:"extattrs,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,6 @@
 # cloud.google.com/go v0.37.4
 cloud.google.com/go/compute/metadata
-# github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200305141429-91388c9466d8
+# github.com/AbsaOSS/infoblox-go-client v0.8.1-0.20200316164013-1a033234161e
 github.com/AbsaOSS/infoblox-go-client
 # github.com/Azure/go-autorest v11.1.2+incompatible
 github.com/Azure/go-autorest/autorest

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.5.3"
+	Version = "0.5.4"
 )


### PR DESCRIPTION
* Fixes #61 by setting low 30 sec TTL so split brain
  timestamp will never be artificially stale
* Based on ABSA enhancement of infoblox-go-client
* Related PR upstream: https://github.com/infobloxopen/infoblox-go-client/pull/89