### PR TITLE
Failover strategy post e2e stabilization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REPO ?= absaoss/ohmyglb
-VERSION ?= $$(operator-sdk up local --operator-flags=-v)
+VERSION ?= $$(operator-sdk run --local --operator-flags=-v)
 VALUES_YAML ?= chart/ohmyglb/values.yaml
 HELM_ARGS ?=
 ETCD_DEBUG_IMAGE ?= quay.io/coreos/etcd:v3.2.25
@@ -52,7 +52,7 @@ use-second-context:
 	kubectl config use-context kind-test-gslb2
 
 .PHONY: deploy-first-ohmyglb
-deploy-first-ohmyglb: HELM_ARGS = --set ohmyglb.hostAlias.enabled=true
+deploy-first-ohmyglb: HELM_ARGS = --set ohmyglb.hostAlias.enabled=true --set ohmyglb.hostAlias.ip="172.17.0.9"
 deploy-first-ohmyglb: deploy-gslb-operator deploy-local-ingress deploy-gslb-cr
 
 .PHONY: deploy-second-ohmyglb

--- a/chart/ohmyglb/Chart.yaml
+++ b/chart/ohmyglb/Chart.yaml
@@ -18,7 +18,7 @@ version: 0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.5.4
+appVersion: 0.5.5
 
 dependencies:
   - name: etcd-operator

--- a/chart/ohmyglb/values.yaml
+++ b/chart/ohmyglb/values.yaml
@@ -6,7 +6,7 @@ global:
   # - name: "image-pull-secret"
 
 ohmyglb:
-  image: absaoss/ohmyglb:v0.5.4
+  image: absaoss/ohmyglb:v0.5.5
   ingressNamespace: "ohmyglb"
   dnsZone: &dnsZone "cloud.example.com" # dnsZone controlled by gslb
   edgeDNSZone: &edgeDNSZone "example.com" # main zone which would contain gslb zone to delegate

--- a/deploy/crds/ohmyglb.absa.oss_gslbs_crd.yaml
+++ b/deploy/crds/ohmyglb.absa.oss_gslbs_crd.yaml
@@ -171,7 +171,6 @@ spec:
                 type:
                   type: string
               required:
-              - primaryGeoTag
               - type
               type: object
           required:

--- a/pkg/apis/ohmyglb/v1beta1/gslb_types.go
+++ b/pkg/apis/ohmyglb/v1beta1/gslb_types.go
@@ -10,7 +10,7 @@ import (
 
 type Strategy struct {
 	Type          string `json:"type"`
-	PrimaryGeoTag string `json:"primaryGeoTag"`
+	PrimaryGeoTag string `json:"primaryGeoTag,omitempty"`
 }
 
 // GslbSpec defines the desired state of Gslb

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.5.4"
+	Version = "0.5.5"
 )


### PR DESCRIPTION
* Make primaryGeoTag optional
* Adjust version fetch to recent operator-sdk versions of CLI
* Adjust HostAlias on testing cluster1 to point to one of the
  workers on cluster2 for proper ext target propagation
* Version bump to include failover strategy