### PR TITLE
Terratest e2e testing proposal

### DIFF
--- a/terratest/examples/roundrobin.yaml
+++ b/terratest/examples/roundrobin.yaml
@@ -1,0 +1,30 @@
+apiVersion: ohmyglb.absa.oss/v1beta1
+kind: Gslb
+metadata:
+  name: test-gslb
+spec:
+  ingress:
+    rules:
+      - host: app1.cloud.example.com # This is the GSLB enabled host that clients would use
+        http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
+          paths:
+            - backend:
+                serviceName: non-existing-app # Gslb should reflect NotFound status
+                servicePort: http
+              path: /
+      - host: app2.cloud.example.com
+        http:
+          paths:
+          - backend:
+              serviceName: unhealthy-app # Gslb should reflect Unhealthy status
+              servicePort: http
+            path: /
+      - host: app3.cloud.example.com
+        http:
+          paths:
+          - backend:
+              serviceName: frontend-podinfo # Gslb should reflect Healthy status and create associated DNS records
+              servicePort: http
+            path: /
+  strategy:
+    type: roundRobin # Use a round robin load balancing strategy, when deciding which downstream clusters to route clients too

--- a/terratest/test/go.mod
+++ b/terratest/test/go.mod
@@ -1,0 +1,3 @@
+module ohmyterratest
+
+go 1.14

--- a/terratest/test/ohmyglb_basic_test.go
+++ b/terratest/test/ohmyglb_basic_test.go
@@ -1,0 +1,46 @@
+package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+// Basic ohmyglb deployment test that is verifying that associated ingress is getting created
+func TestOhmyglbBasicExample(t *testing.T) {
+	t.Parallel()
+
+	// Path to the Kubernetes resource config we will test
+	kubeResourcePath, err := filepath.Abs("../examples/roundrobin.yaml")
+	require.NoError(t, err)
+
+	// To ensure we can reuse the resource config on the same cluster to test different scenarios, we setup a unique
+	// namespace for the resources for this test.
+	// Note that namespaces must be lowercase.
+	namespaceName := fmt.Sprintf("kubernetes-basic-example-%s", strings.ToLower(random.UniqueId()))
+
+	// Here we choose to use the defaults, which is:
+	// - HOME/.kube/config for the kubectl config file
+	// - Current context of the kubectl config file
+	// - Random namespace
+	options := k8s.NewKubectlOptions("", "", namespaceName)
+
+	k8s.CreateNamespace(t, options, namespaceName)
+
+	defer k8s.DeleteNamespace(t, options, namespaceName)
+
+	defer k8s.KubectlDelete(t, options, kubeResourcePath)
+
+	k8s.KubectlApply(t, options, kubeResourcePath)
+
+	k8s.WaitUntilIngressAvailable(t, options, "test-gslb", 60, 1*time.Second)
+	ingress := k8s.GetIngress(t, options, "test-gslb")
+	require.Equal(t, ingress.Name, "test-gslb")
+}


### PR DESCRIPTION
This PR contains simple example of ohmyglb testing
with https://terratest.gruntwork.io/

I see multiple benefits using this framework:

* It supports kubernetes visibly well with resonable amount of k8s modules
  https://github.com/gruntwork-io/terratest/tree/master/modules/k8s
* It has bunch of useful testing helpers like
  https://github.com/gruntwork-io/terratest/tree/master/modules/http-helper
* It's a golang so we are staying in context with the main codebase