### PR TITLE
Fix cluster namespaces permission for ohmyglb

### DIFF
--- a/chart/ohmyglb/templates/role.yaml
+++ b/chart/ohmyglb/templates/role.yaml
@@ -74,3 +74,9 @@ rules:
   - dnsendpoints
   verbs:
   - '*'
+- apiGroups:
+  - '*'
+  resources:
+  - namespaces
+  verbs:
+  - 'list'


### PR DESCRIPTION
- Adds permissions to list namespaces for `ohmyglb` ClusterRole. 
   Lack of permissions prevented CR metrics generation for ohmyglb deployment:
    ```
    {"level":"info","ts":1585940196.2318976,"logger":"cmd","msg":"Could not generate and serve custom resource metrics","error":"namespaces is forbidden: User \"system:serviceaccount:ohmyglb:ohmyglb\" cannot list resource \"namespaces\" in API group \"\" at the cluster scope"}
    ``` 