### PR TITLE
Time measure failover process

### DIFF
--- a/terratest/test/ohmyglb_basic_failover_test.go
+++ b/terratest/test/ohmyglb_basic_failover_test.go
@@ -71,18 +71,20 @@ func TestOhmyglbBasicFailoverExample(t *testing.T) {
 
 	assertGslbStatus(t, optionsContext1, gslbName, "terratest-failover.cloud.example.com:Unhealthy")
 
-	expectedIPsAfterFailover := GetIngressIPs(t, optionsContext2, gslbName)
+	t.Run("failover happens as expected", func(t *testing.T) {
+		expectedIPsAfterFailover := GetIngressIPs(t, optionsContext2, gslbName)
 
-	afterFailoverResponse, err := DoWithRetryWaitingForValueE(
-		t,
-		"Wait for failover to happen and coredns to pickup new values...",
-		300,
-		1*time.Second,
-		func() ([]string, error) { return Dig(t, "localhost", 53, "terratest-failover.cloud.example.com") },
-		expectedIPsAfterFailover)
-	require.NoError(t, err)
+		afterFailoverResponse, err := DoWithRetryWaitingForValueE(
+			t,
+			"Wait for failover to happen and coredns to pickup new values...",
+			300,
+			1*time.Second,
+			func() ([]string, error) { return Dig(t, "localhost", 53, "terratest-failover.cloud.example.com") },
+			expectedIPsAfterFailover)
+		require.NoError(t, err)
 
-	assert.Equal(t, afterFailoverResponse, expectedIPsAfterFailover)
+		assert.Equal(t, afterFailoverResponse, expectedIPsAfterFailover)
+	})
 
 }
 


### PR DESCRIPTION
* Move failover check retry functions to subtest
  to enable gathering of time metrics from the test suite
* Current results look like:
```
--- PASS: TestOhmyglbBasicFailoverExample (289.48s)
    --- PASS: TestOhmyglbBasicFailoverExample/failover_happens_as_expected (157.23s)
PASS
ok  	ohmyterratest	291.032s
```
* This way we objectively measured that the whole failover process
  (CRD->etcd->coredns) update takes more than 2.5 minutes

There is definitely something to improve.