### PR TITLE
Reduce external-dns sync interval to 20s

### DIFF
--- a/chart/ohmyglb/templates/external-dns/external-dns.yaml
+++ b/chart/ohmyglb/templates/external-dns/external-dns.yaml
@@ -69,6 +69,7 @@ spec:
         - --log-level=debug # debug only
         - --registry=noop # disable local external-dns ownership, see https://github.com/kubernetes-sigs/external-dns/issues/1414
         - --annotation-filter=ohmyglb.absa.oss/dnstype=local # filter out only relevant DNSEntrypoints
+        - --interval=20s # perform synchronization more frequently than default 1m for faster load balancing 
         env:
         - name: ETCD_URLS
           value: http://etcd-cluster-client:2379


### PR DESCRIPTION
* Reduce external-dns ( CRD -> etcd ) sync interval to 20s
* Value is picked to be sligtly below default 30s DNS TTL
  we are currently working with
* Terratest results:
```
--- PASS: TestOhmyglbBasicFailoverExample (157.84s)
    --- PASS: TestOhmyglbBasicFailoverExample/failover_happens_as_expected (35.41s)
```
* This way we reduced failover(or any kind of load balancing
  reconfiguration) from ~2.5 min down to 35 seconds
  See https://github.com/AbsaOSS/ohmyglb/pull/80 for initial values