### PR TITLE
Helm package and publish on release event

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,18 @@
+name: Helm Publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dave-mcconnell/helm-gh-pages-microservices@master
+        with:
+          access-token: ${{ secrets.CR_TOKEN }}
+          source-charts-folder: 'chart'
+          destination-repo: absaoss/ohmyglb
+          destination-branch: gh-pages


### PR DESCRIPTION
* Github workflow conf reacts to release publish event
* https://github.com/dave-mcconnell/helm-gh-pages-microservices action to `helm package` and publish to github pages
* Dedicated `gh-pages` branch to not to mess with the main codebase and keep helm repo separately
* Resolves #75