### PR TITLE
Etcd-operator as own subchart

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Golang lint and test
-on: [push, pull_request]
+on: push
 jobs:
   go-test:
     name: Go Test

--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -1,6 +1,6 @@
 name: Gosec
 
-on: [push, pull_request]
+on: push
 
 jobs:
   security_tests:

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -1,6 +1,6 @@
 name: Terratest
 
-on: [push, pull_request]
+on: push
 
 jobs:
   terratest:

--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,4 @@ tags
 # End of idea tools
  
 # Exclude chart tar.gz files
-chart/ohmyglb/charts/
+chart/ohmyglb/charts/*.tgz

--- a/chart/ohmyglb/Chart.lock
+++ b/chart/ohmyglb/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: etcd-operator
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 0.10.2
 - name: coredns
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.8.4
-digest: sha256:6589f53eec3b5c7e518765caa72bfad4a61c325f8fbd4a999e849616098f2559
-generated: "2020-01-15T14:29:26.990868+01:00"
+digest: sha256:e7b93a9c2532192e609ba4fb56f240e1a61032e8b1ee746a73bdf0befa298f01
+generated: "2020-04-20T17:17:40.352258+02:00"

--- a/chart/ohmyglb/Chart.yaml
+++ b/chart/ohmyglb/Chart.yaml
@@ -14,16 +14,13 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 0.5.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.5.6
 
 dependencies:
-  - name: etcd-operator
-    repository: https://kubernetes-charts.storage.googleapis.com
-    version: 0.10.2
   - name: coredns
     repository: https://kubernetes-charts.storage.googleapis.com
     version: 1.8.4

--- a/chart/ohmyglb/charts/etcd-operator/.helmignore
+++ b/chart/ohmyglb/charts/etcd-operator/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/chart/ohmyglb/charts/etcd-operator/Chart.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+description: CoreOS etcd-operator Helm chart for Kubernetes
+name: etcd-operator
+version: 0.10.3
+appVersion: 0.9.4
+home: https://github.com/coreos/etcd-operator
+icon: https://raw.githubusercontent.com/coreos/etcd/master/logos/etcd-horizontal-color.png
+sources:
+- https://github.com/coreos/etcd-operator
+maintainers:
+- name: lachie83
+  email: lachlan@deis.com
+- name: alejandroEsc
+  email: jaescobar.cell@gmail.com

--- a/chart/ohmyglb/charts/etcd-operator/OWNERS
+++ b/chart/ohmyglb/charts/etcd-operator/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- lachie83
+- alejandroEsc
+reviewers:
+- lachie83
+- alejandroEsc

--- a/chart/ohmyglb/charts/etcd-operator/README.md
+++ b/chart/ohmyglb/charts/etcd-operator/README.md
@@ -1,0 +1,169 @@
+# CoreOS etcd-operator
+
+[etcd-operator](https://coreos.com/blog/introducing-the-etcd-operator.html) Simplify etcd cluster
+configuration and management.
+
+__DISCLAIMER:__ While this chart has been well-tested, the etcd-operator is still currently in beta.
+Current project status is available [here](https://github.com/coreos/etcd-operator).
+
+## Introduction
+
+This chart bootstraps an etcd-operator and allows the deployment of etcd-cluster(s).
+
+## Official Documentation
+
+Official project documentation found [here](https://github.com/coreos/etcd-operator)
+
+## Prerequisites
+
+- Kubernetes 1.4+ with Beta APIs enabled
+- __Suggested:__ PV provisioner support in the underlying infrastructure to support backups
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install stable/etcd-operator --name my-release
+```
+
+Note that by default chart installs etcd operator only. If you want to also deploy `etcd` cluster, enable `customResources.createEtcdClusterCRD` flag:
+```bash
+$ helm install --name my-release --set customResources.createEtcdClusterCRD=true stable/etcd-operator
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components EXCEPT the persistent volume.
+
+## Updating
+Once you have a new chart version, you can update your deployment with:
+```
+$ helm upgrade my-release stable/etcd-operator
+```
+
+Example resizing etcd cluster from `3` to `5` nodes during helm upgrade:
+```bash
+$ helm upgrade my-release --set etcdCluster.size=5 --set customResources.createEtcdClusterCRD=true stable/etcd-operator
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the etcd-operator chart and their default values.
+
+| Parameter                                         | Description                                                          | Default                                        |
+| ------------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------------- |
+| `rbac.create`                                     | Install required RBAC service account, roles and rolebindings        | `true`                                         |
+| `rbac.apiVersion`                                 | RBAC api version `v1alpha1\|v1beta1`                                 | `v1beta1`                                      |
+| `serviceAccount.create`                           | Flag to create the service account                                   | `true`                                         |
+| `serviceAccount.name`                             | Name of the service account resource when RBAC is enabled            | `etcd-operator-sa`                             |
+| `deployments.etcdOperator`                        | Deploy the etcd cluster operator                                     | `true`                                         |
+| `deployments.backupOperator`                      | Deploy the etcd backup operator                                      | `true`                                         |
+| `deployments.restoreOperator`                     | Deploy the etcd restore operator                                     | `true`                                         |
+| `customResources.createEtcdClusterCRD`            | Create a custom resource: EtcdCluster                                | `false`                                        |
+| `customResources.createBackupCRD`                 | Create an a custom resource: EtcdBackup                              | `false`                                        |
+| `customResources.createRestoreCRD`                | Create an a custom resource: EtcdRestore                             | `false`                                        |
+| `etcdOperator.name`                               | Etcd Operator name                                                   | `etcd-operator`                                |
+| `etcdOperator.replicaCount`                       | Number of operator replicas to create (only 1 is supported)          | `1`                                            |
+| `etcdOperator.image.repository`                   | etcd-operator container image                                        | `quay.io/coreos/etcd-operator`                 |
+| `etcdOperator.image.tag`                          | etcd-operator container image tag                                    | `v0.9.3`                                       |
+| `etcdOperator.image.pullpolicy`                   | etcd-operator container image pull policy                            | `Always`                                       |
+| `etcdOperator.resources.cpu`                      | CPU limit per etcd-operator pod                                      | `100m`                                         |
+| `etcdOperator.resources.memory`                   | Memory limit per etcd-operator pod                                   | `128Mi`                                        |
+| `etcdOperator.securityContext`                    | SecurityContext for etcd operator                                    | `{}`                                           |
+| `etcdOperator.nodeSelector`                       | Node labels for etcd operator pod assignment                         | `{}`                                           |
+| `etcdOperator.podAnnotations`                     | Annotations for the etcd operator pod                                | `{}`                                           |
+| `etcdOperator.commandArgs`                        | Additional command arguments                                         | `{}`                                           |
+| `backupOperator.name`                             | Backup operator name                                                 | `etcd-backup-operator`                         |
+| `backupOperator.replicaCount`                     | Number of operator replicas to create (only 1 is supported)          | `1`                                            |
+| `backupOperator.image.repository`                 | Operator container image                                             | `quay.io/coreos/etcd-operator`                 |
+| `backupOperator.image.tag`                        | Operator container image tag                                         | `v0.9.3`                                       |
+| `backupOperator.image.pullpolicy`                 | Operator container image pull policy                                 | `Always`                                       |
+| `backupOperator.resources.cpu`                    | CPU limit per etcd-operator pod                                      | `100m`                                         |
+| `backupOperator.resources.memory`                 | Memory limit per etcd-operator pod                                   | `128Mi`                                        |
+| `backupOperator.securityContext`                  | SecurityContext for etcd backup operator                             | `{}`                                           |
+| `backupOperator.spec.storageType`                 | Storage to use for backup file, currently only S3 supported          | `S3`                                           |
+| `backupOperator.spec.s3.s3Bucket`                 | Bucket in S3 to store backup file                                    |                                                |
+| `backupOperator.spec.s3.awsSecret`                | Name of kubernetes secret containing aws credentials                 |                                                |
+| `backupOperator.nodeSelector`                     | Node labels for etcd operator pod assignment                         | `{}`                                           |
+| `backupOperator.commandArgs`                      | Additional command arguments                                         | `{}`                                           |
+| `restoreOperator.name`                            | Restore operator name                                                | `etcd-backup-operator`                         |
+| `restoreOperator.replicaCount`                    | Number of operator replicas to create (only 1 is supported)          | `1`                                            |
+| `restoreOperator.image.repository`                | Operator container image                                             | `quay.io/coreos/etcd-operator`                 |
+| `restoreOperator.image.tag`                       | Operator container image tag                                         | `v0.9.3`                                       |
+| `restoreOperator.image.pullpolicy`                | Operator container image pull policy                                 | `Always`                                       |
+| `restoreOperator.resources.cpu`                   | CPU limit per etcd-operator pod                                      | `100m`                                         |
+| `restoreOperator.resources.memory`                | Memory limit per etcd-operator pod                                   | `128Mi`                                        |
+| `restoreOperator.securityContext`                 | SecurityContext for etcd restore operator                            | `{}`                                           |
+| `restoreOperator.spec.s3.path`                    | Path in S3 bucket containing the backup file                         |                                                |
+| `restoreOperator.spec.s3.awsSecret`               | Name of kubernetes secret containing aws credentials                 |                                                |
+| `restoreOperator.nodeSelector`                    | Node labels for etcd operator pod assignment                         | `{}`                                           |
+| `restoreOperator.commandArgs`                     | Additional command arguments                                         | `{}`                                           |
+| `etcdCluster.name`                                | etcd cluster name                                                    | `etcd-cluster`                                 |
+| `etcdCluster.size`                                | etcd cluster size                                                    | `3`                                            |
+| `etcdCluster.version`                             | etcd cluster version                                                 | `3.2.25`                                       |
+| `etcdCluster.image.repository`                    | etcd container image                                                 | `quay.io/coreos/etcd-operator`                 |
+| `etcdCluster.image.tag`                           | etcd container image tag                                             | `v3.2.25`                                      |
+| `etcdCluster.image.pullPolicy`                    | etcd container image pull policy                                     | `Always`                                       |
+| `etcdCluster.enableTLS`                           | Enable use of TLS                                                    | `false`                                        |
+| `etcdCluster.tls.static.member.peerSecret`        | Kubernetes secret containing TLS peer certs                          | `etcd-peer-tls`                                |
+| `etcdCluster.tls.static.member.serverSecret`      | Kubernetes secret containing TLS server certs                        | `etcd-server-tls`                              |
+| `etcdCluster.tls.static.operatorSecret`           | Kubernetes secret containing TLS client certs                        | `etcd-client-tls`                              |
+| `etcdCluster.pod.antiAffinity`                    | Whether etcd cluster pods should have an antiAffinity                | `false`                                        |
+| `etcdCluster.pod.resources.limits.cpu`            | CPU limit per etcd cluster pod                                       | `100m`                                         |
+| `etcdCluster.pod.resources.limits.memory`         | Memory limit per etcd cluster pod                                    | `128Mi`                                        |
+| `etcdCluster.pod.resources.requests.cpu`          | CPU request per etcd cluster pod                                     | `100m`                                         |
+| `etcdCluster.pod.resources.requests.memory`       | Memory request per etcd cluster pod                                  | `128Mi`                                        |
+| `etcdCluster.pod.nodeSelector`                    | Node labels for etcd cluster pod assignment                          | `{}`                                           |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
+
+```bash
+$ helm install --name my-release --set image.tag=v0.2.1 stable/etcd-operator
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while
+installing the chart. For example:
+
+```bash
+$ helm install --name my-release --values values.yaml stable/etcd-operator
+```
+
+## RBAC
+By default the chart will install the recommended RBAC roles and rolebindings.
+
+To determine if your cluster supports this running the following:
+
+```console
+$ kubectl api-versions | grep rbac
+```
+
+You also need to have the following parameter on the api server. See the following document for how to enable [RBAC](https://kubernetes.io/docs/admin/authorization/rbac/)
+
+```
+--authorization-mode=RBAC
+```
+
+If the output contains "beta" or both "alpha" and "beta" you can may install rbac by default, if not, you may turn RBAC off as described below.
+
+### RBAC role/rolebinding creation
+
+RBAC resources are enabled by default. To disable RBAC do the following:
+
+```console
+$ helm install --name my-release stable/etcd-operator --set rbac.create=false
+```
+
+### Changing RBAC manifest apiVersion
+
+By default the RBAC resources are generated with the "v1beta1" apiVersion. To use "v1alpha1" do the following:
+
+```console
+$ helm install --name my-release stable/etcd-operator --set rbac.install=true,rbac.apiVersion=v1alpha1
+```

--- a/chart/ohmyglb/charts/etcd-operator/crds/etcd-cluster-crd.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/crds/etcd-cluster-crd.yaml
@@ -1,0 +1,22 @@
+# Synced with https://github.com/coreos/etcd-operator/blob/master/pkg/util/k8sutil/crd.go
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: etcdclusters.etcd.database.coreos.com
+  labels:
+    app: etcd-operator.name
+  annotations:
+    helm.sh/hook: crd-install
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  group: etcd.database.coreos.com
+  scope: Namespaced
+  version: v1beta2
+  names:
+    kind: EtcdCluster
+    listKind: EtcdClusterList
+    singular: etcdcluster
+    plural: etcdclusters
+    shortNames:
+    - etcd

--- a/chart/ohmyglb/charts/etcd-operator/templates/NOTES.txt
+++ b/chart/ohmyglb/charts/etcd-operator/templates/NOTES.txt
@@ -1,0 +1,27 @@
+{{- if .Values.customResources.createEtcdClusterCRD -}}
+1. Watch etcd cluster start
+  kubectl get pods -l etcd_cluster={{ .Values.etcdCluster.name }} --namespace {{ .Release.Namespace }} -w
+
+2. Confirm etcd cluster is healthy
+  $ kubectl run --rm -i --tty --env="ETCDCTL_API=3" --env="ETCDCTL_ENDPOINTS=http://{{ .Values.etcdCluster.name }}-client:2379" --namespace {{ .Release.Namespace }} etcd-test --image quay.io/coreos/etcd --restart=Never -- /bin/sh -c 'watch -n1 "etcdctl  member list"'
+
+3. Interact with the cluster!
+  $ kubectl run --rm -i --tty --env ETCDCTL_API=3 --namespace {{ .Release.Namespace }} etcd-test --image quay.io/coreos/etcd --restart=Never -- /bin/sh
+  / # etcdctl --endpoints http://{{ .Values.etcdCluster.name }}-client:2379 put foo bar
+  / # etcdctl --endpoints http://{{ .Values.etcdCluster.name }}-client:2379 get foo
+  OK
+  (ctrl-D to exit)
+  
+4. Optional
+  Check the etcd-operator logs
+  export POD=$(kubectl get pods -l app={{ template "etcd-operator.fullname" . }} --namespace {{ .Release.Namespace }} --output name)
+  kubectl logs $POD --namespace={{ .Release.Namespace }}
+
+{{- else -}}
+1. etcd-operator deployed.
+  If you would like to deploy an etcd-cluster set 'customResources.createEtcdClusterCRD' to true in values.yaml
+  Check the etcd-operator logs
+    export POD=$(kubectl get pods -l app={{ template "etcd-operator.fullname" . }} --namespace {{ .Release.Namespace }} --output name)
+    kubectl logs $POD --namespace={{ .Release.Namespace }}
+
+{{- end -}}

--- a/chart/ohmyglb/charts/etcd-operator/templates/_helpers.tpl
+++ b/chart/ohmyglb/charts/etcd-operator/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "etcd-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "etcd-operator.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.etcdOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "etcd-backup-operator.name" -}}
+{{- default .Chart.Name .Values.backupOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "etcd-backup-operator.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.backupOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "etcd-restore-operator.name" -}}
+{{- default .Chart.Name .Values.restoreOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "etcd-restore-operator.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s-%s" .Release.Name $name .Values.restoreOperator.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the etcd-operator service account to use
+*/}}
+{{- define "etcd-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "etcd-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/chart/ohmyglb/charts/etcd-operator/templates/backup-etcd-crd.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/templates/backup-etcd-crd.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.customResources.createBackupCRD }}
+---
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdBackup"
+metadata:
+  name: {{ template "etcd-backup-operator.fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd-backup-operator.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  clusterName: {{ .Values.etcdCluster.name }}
+{{ toYaml .Values.backupOperator.spec | indent 2 }}
+{{- end}}

--- a/chart/ohmyglb/charts/etcd-operator/templates/backup-operator-deployment.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/templates/backup-operator-deployment.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.deployments.backupOperator }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "etcd-backup-operator.fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd-backup-operator.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "etcd-backup-operator.fullname" . }}
+      release: {{ .Release.Name }}
+  replicas: {{ .Values.backupOperator.replicaCount }}
+  template:
+    metadata:
+      name: {{ template "etcd-backup-operator.fullname" . }}
+      labels:
+        app: {{ template "etcd-backup-operator.fullname" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "etcd-operator.serviceAccountName" . }}
+      containers:
+      - name: {{ .Values.backupOperator.name }}
+        image: "{{ .Values.backupOperator.image.repository }}:{{ .Values.backupOperator.image.tag }}"
+        imagePullPolicy: {{ .Values.backupOperator.image.pullPolicy }}
+        command:
+        - etcd-backup-operator
+{{- range $key, $value := .Values.backupOperator.commandArgs }}
+        - "--{{ $key }}={{ $value }}"
+{{- end }}
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        resources:
+          limits:
+            cpu: {{ .Values.backupOperator.resources.cpu }}
+            memory: {{ .Values.backupOperator.resources.memory }}
+          requests:
+            cpu: {{ .Values.backupOperator.resources.cpu }}
+            memory: {{ .Values.backupOperator.resources.memory }}
+    {{- if .Values.backupOperator.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.backupOperator.nodeSelector | nindent 8 }}
+    {{- end }}
+    {{- if .Values.backupOperator.securityContext }}
+      securityContext: {{ toYaml .Values.backupOperator.securityContext | nindent 8 }}
+    {{- end }}
+    {{- if .Values.backupOperator.tolerations }}
+      tolerations: {{ toYaml .Values.backupOperator.tolerations | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/chart/ohmyglb/charts/etcd-operator/templates/crds.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/templates/crds.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.deployments.etcdOperator }}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}
+{{- end }}

--- a/chart/ohmyglb/charts/etcd-operator/templates/etcd-cluster-crd.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/templates/etcd-cluster-crd.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.customResources.createEtcdClusterCRD }}
+---
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdCluster"
+metadata:
+  name: {{ .Values.etcdCluster.name }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd-operator.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  size: {{ .Values.etcdCluster.size }}
+  version: "{{ .Values.etcdCluster.version }}"
+  repository: "{{ .Values.etcdCluster.image.repository }}"
+  pod:
+{{ toYaml .Values.etcdCluster.pod | indent 4 }}
+  {{- if .Values.etcdCluster.enableTLS }}
+  TLS:
+{{ toYaml .Values.etcdCluster.tls | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/ohmyglb/charts/etcd-operator/templates/operator-cluster-role.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/templates/operator-cluster-role.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/{{ .Values.rbac.apiVersion }}
+kind: ClusterRole
+metadata:
+  name: {{ template "etcd-operator.fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd-operator.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - etcd.database.coreos.com
+  resources:
+  - etcdclusters
+  - etcdbackups
+  - etcdrestores
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+{{- end }}

--- a/chart/ohmyglb/charts/etcd-operator/templates/operator-clusterrole-binding.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/templates/operator-clusterrole-binding.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.rbac.create .Values.deployments.etcdOperator }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/{{ required "A valid .Values.rbac.apiVersion entry required!" .Values.rbac.apiVersion }}
+metadata:
+  name: {{ template "etcd-operator.fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd-operator.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "etcd-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "etcd-operator.fullname" . }}
+{{- end }}

--- a/chart/ohmyglb/charts/etcd-operator/templates/operator-deployment.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/templates/operator-deployment.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.deployments.etcdOperator }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "etcd-operator.fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd-operator.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "etcd-operator.fullname" . }}
+      release: {{ .Release.Name }}
+  replicas: {{ .Values.etcdOperator.replicaCount }}
+  template:
+    metadata:
+      name: {{ template "etcd-operator.fullname" . }}
+      labels:
+        app: {{ template "etcd-operator.fullname" . }}
+        release: {{ .Release.Name }}
+      annotations: {{ toYaml .Values.etcdOperator.podAnnotations | nindent 8}}
+    spec:
+      serviceAccountName: {{ template "etcd-operator.serviceAccountName" . }}
+      containers:
+      - name: {{ template "etcd-operator.fullname" . }}
+        image: "{{ .Values.etcdOperator.image.repository }}:{{ .Values.etcdOperator.image.tag }}"
+        imagePullPolicy: {{ .Values.etcdOperator.image.pullPolicy }}
+        command:
+        - etcd-operator
+{{- range $key, $value := .Values.etcdOperator.commandArgs }}
+        - "--{{ $key }}={{ $value }}"
+{{- end }}
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        resources:
+          limits:
+            cpu: {{ .Values.etcdOperator.resources.cpu }}
+            memory: {{ .Values.etcdOperator.resources.memory }}
+          requests:
+            cpu: {{ .Values.etcdOperator.resources.cpu }}
+            memory: {{ .Values.etcdOperator.resources.memory }}
+        {{- if .Values.etcdOperator.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: {{ .Values.etcdOperator.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.etcdOperator.livenessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.etcdOperator.livenessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.etcdOperator.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.etcdOperator.livenessProbe.failureThreshold }}
+        {{- end}}
+        {{- if .Values.etcdOperator.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: {{ .Values.etcdOperator.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.etcdOperator.readinessProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.etcdOperator.readinessProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.etcdOperator.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.etcdOperator.readinessProbe.failureThreshold }}
+        {{- end }}
+    {{- if .Values.etcdOperator.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.etcdOperator.nodeSelector | nindent 8 }}
+    {{- end }}
+    {{- if .Values.etcdOperator.securityContext }}
+      securityContext: {{ toYaml .Values.etcdOperator.securityContext | nindent 8 }}
+    {{- end }}
+    {{- if .Values.etcdOperator.tolerations }}
+      tolerations: {{ toYaml .Values.etcdOperator.tolerations | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/chart/ohmyglb/charts/etcd-operator/templates/operator-service-account.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/templates/operator-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.serviceAccount.create .Values.deployments.etcdOperator }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "etcd-operator.serviceAccountName" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd-operator.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- end }}

--- a/chart/ohmyglb/charts/etcd-operator/templates/restore-etcd-crd.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/templates/restore-etcd-crd.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.customResources.createRestoreCRD }}
+---
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdRestore"
+metadata:
+  # An EtcdCluster with the same name will be created
+  name: {{ .Values.etcdCluster.name }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd-restore-operator.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": "post-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  clusterSpec:
+    size: {{ .Values.etcdCluster.size }}
+    baseImage: "{{ .Values.etcdCluster.image.repository }}"
+    version: {{ .Values.etcdCluster.image.tag }}
+    pod:
+{{ toYaml .Values.etcdCluster.pod | indent 6 }}
+    {{- if .Values.etcdCluster.enableTLS }}
+    TLS:
+{{ toYaml .Values.etcdCluster.tls | indent 6 }}
+    {{- end }}
+{{ toYaml .Values.restoreOperator.spec | indent 2 }}
+{{- end}}

--- a/chart/ohmyglb/charts/etcd-operator/templates/restore-operator-deployment.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/templates/restore-operator-deployment.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.deployments.restoreOperator }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "etcd-restore-operator.fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd-restore-operator.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "etcd-restore-operator.name" . }}
+      release: {{ .Release.Name }}
+  replicas: {{ .Values.restoreOperator.replicaCount }}
+  template:
+    metadata:
+      name: {{ template "etcd-restore-operator.fullname" . }}
+      labels:
+        app: {{ template "etcd-restore-operator.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "etcd-operator.serviceAccountName" . }}
+      containers:
+      - name: {{ .Values.restoreOperator.name }}
+        image: "{{ .Values.restoreOperator.image.repository }}:{{ .Values.restoreOperator.image.tag }}"
+        imagePullPolicy: {{ .Values.restoreOperator.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.restoreOperator.port }}
+        command:
+        - etcd-restore-operator
+{{- range $key, $value := .Values.restoreOperator.commandArgs }}
+        - "--{{ $key }}={{ $value }}"
+{{- end }}
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SERVICE_ADDR
+          value: "{{ .Values.restoreOperator.name }}:{{ .Values.restoreOperator.port }}"
+        resources:
+          limits:
+            cpu: {{ .Values.restoreOperator.resources.cpu }}
+            memory: {{ .Values.restoreOperator.resources.memory }}
+          requests:
+            cpu: {{ .Values.restoreOperator.resources.cpu }}
+            memory: {{ .Values.restoreOperator.resources.memory }}
+    {{- if .Values.restoreOperator.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.restoreOperator.nodeSelector | nindent 8 }}
+    {{- end }}
+    {{- if .Values.restoreOperator.securityContext }}
+      securityContext: {{ toYaml .Values.restoreOperator.securityContext | nindent 8 }}
+    {{- end }}
+    {{- if .Values.restoreOperator.tolerations }}
+      tolerations: {{ toYaml .Values.restoreOperator.tolerations | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/chart/ohmyglb/charts/etcd-operator/templates/restore-operator-service.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/templates/restore-operator-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.deployments.restoreOperator }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.restoreOperator.name }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: {{ template "etcd-restore-operator.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  ports:
+  - protocol: TCP
+    name: http-etcd-restore-port
+    port: {{ .Values.restoreOperator.port }}
+  selector:
+    app: {{ template "etcd-restore-operator.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/chart/ohmyglb/charts/etcd-operator/values.yaml
+++ b/chart/ohmyglb/charts/etcd-operator/values.yaml
@@ -1,0 +1,160 @@
+# Default values for etcd-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
+
+## Install Default RBAC roles and bindings
+rbac:
+  create: true
+  apiVersion: v1
+
+## Service account name and whether to create it
+serviceAccount:
+  create: true
+  name:
+
+# Select what to deploy
+deployments:
+  etcdOperator: true
+  # one time deployment, delete once completed,
+  # Ref: https://github.com/coreos/etcd-operator/blob/master/doc/user/walkthrough/backup-operator.md
+  backupOperator: true
+  # one time deployment, delete once completed
+  # Ref: https://github.com/coreos/etcd-operator/blob/master/doc/user/walkthrough/restore-operator.md
+  restoreOperator: true
+
+# creates custom resources, not all required,
+# you could use `helm template --values <values.yaml> --name release_name ... `
+# and create the resources yourself to deploy on your cluster later
+customResources:
+  createEtcdClusterCRD: false
+  createBackupCRD: false
+  createRestoreCRD: false
+
+# etcdOperator
+etcdOperator:
+  name: etcd-operator
+  replicaCount: 1
+  image:
+    repository: quay.io/coreos/etcd-operator
+    tag: v0.9.4
+    pullPolicy: Always
+  resources:
+    cpu: 100m
+    memory: 128Mi
+  ## Node labels for etcd-operator pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  nodeSelector: {}
+  ## additional command arguments go here; will be translated to `--key=value` form
+  ## e.g., analytics: true
+  commandArgs: {}
+  tolerations: []
+  ## Configurable health checks against the /readyz endpoint that etcd-operator exposes
+  readinessProbe:
+    enabled: false
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
+  livenessProbe:
+    enabled: false
+    initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
+
+# backup spec
+backupOperator:
+  name: etcd-backup-operator
+  replicaCount: 1
+  image:
+    repository: quay.io/coreos/etcd-operator
+    tag: v0.9.4
+    pullPolicy: Always
+  resources:
+    cpu: 100m
+    memory: 128Mi
+  spec:
+    storageType: S3
+    s3:
+      s3Bucket:
+      awsSecret:
+  ## Node labels for etcd pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  nodeSelector: {}
+  ## additional command arguments go here; will be translated to `--key=value` form
+  ## e.g., analytics: true
+  commandArgs: {}
+  securityContext: {}
+  tolerations: []
+
+# restore spec
+restoreOperator:
+  name: etcd-restore-operator
+  replicaCount: 1
+  image:
+    repository: quay.io/coreos/etcd-operator
+    tag: v0.9.4
+    pullPolicy: Always
+  port: 19999
+  resources:
+    cpu: 100m
+    memory: 128Mi
+  spec:
+    s3:
+      # The format of "path" must be: "<s3-bucket-name>/<path-to-backup-file>"
+      # e.g: "etcd-snapshot-bucket/v1/default/example-etcd-cluster/3.2.10_0000000000000001_etcd.backup"
+      path:
+      awsSecret:
+  ## Node labels for etcd pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  nodeSelector: {}
+  ## additional command arguments go here; will be translated to `--key=value` form
+  ## e.g., analytics: true
+  commandArgs: {}
+  securityContext: {}
+  tolerations: []
+
+## etcd-cluster specific values
+etcdCluster:
+  name: etcd-cluster
+  size: 3
+  version: 3.2.25
+  image:
+    repository: quay.io/coreos/etcd
+    tag: v3.2.25
+    pullPolicy: Always
+  enableTLS: false
+  # TLS configs
+  tls:
+    static:
+      member:
+        peerSecret: etcd-peer-tls
+        serverSecret: etcd-server-tls
+      operatorSecret: etcd-client-tls
+  ## etcd cluster pod specific values
+  ## Ref: https://github.com/coreos/etcd-operator/blob/master/doc/user/spec_examples.md#three-members-cluster-with-resource-requirement
+  pod:
+    busyboxImage: busybox:1.28.0-glibc
+    ## Antiaffinity for etcd pod assignment
+    ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    antiAffinity: false
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    ## Node labels for etcd pod assignment
+    ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+    nodeSelector: {}
+    securityContext: {}
+    tolerations: []

--- a/chart/ohmyglb/values.yaml
+++ b/chart/ohmyglb/values.yaml
@@ -80,6 +80,6 @@ coredns:
 infoblox:
   enabled: false
   gridHost: 10.0.0.1
-  wapiVersion: 2.3.1 
+  wapiVersion: 2.3.1
   wapiPort: 443
   sslVerify: true


### PR DESCRIPTION
* Move etcd-operator to own subchart because upstream merge
  of https://github.com/helm/charts/pull/20084 looks pretty much hopeless
* Bump and sync chart version as per maintainers agreement
* Occasional trailing whitespace removal