### PR TITLE
Add capability to end-to-end test HEAD of the branch

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -21,7 +21,12 @@ jobs:
       - name: Ohmyglb deployment
         env:
           NODE_ROLE: control-plane
+          TEST_CURRENT_COMMIT: yes
         run: |
+          OPERATOR_SDK_VERSION=v0.16.0
+          wget https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -O ./operator-sdk
+          chmod +x ./operator-sdk
+          export PATH=.:$PATH
           ./deploy/full.sh
           kubectl get pods -A
           make use-second-context

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ VALUES_YAML ?= chart/ohmyglb/values.yaml
 HELM_ARGS ?=
 ETCD_DEBUG_IMAGE ?= quay.io/coreos/etcd:v3.2.25
 GSLB_DOMAIN ?= cloud.example.com
-HOST_ALIAS_IP1 ?=
-HOST_ALIAS_IP2 ?=
+HOST_ALIAS_IP1 ?= 172.17.0.9
+HOST_ALIAS_IP2 ?= 172.17.0.5
+OHMYGLB_IMAGE ?= absaoss/ohmyglb:$(VERSION)
 
 .PHONY: up-local
 up-local: create-test-ns
@@ -58,16 +59,16 @@ use-second-context:
 	kubectl config use-context kind-test-gslb2
 
 .PHONY: deploy-first-ohmyglb
-deploy-first-ohmyglb: HELM_ARGS = --set ohmyglb.hostAlias.enabled=true --set ohmyglb.hostAlias.ip="$(HOST_ALIAS_IP1)"
+deploy-first-ohmyglb: HELM_ARGS = --set ohmyglb.hostAlias.enabled=true --set ohmyglb.hostAlias.ip="$(HOST_ALIAS_IP1)" --set ohmyglb.image=$(OHMYGLB_IMAGE)
 deploy-first-ohmyglb: deploy-gslb-operator deploy-local-ingress
 
 .PHONY: deploy-second-ohmyglb
-deploy-second-ohmyglb: HELM_ARGS = --set ohmyglb.hostAlias.enabled=true --set ohmyglb.clusterGeoTag="us" --set ohmyglb.extGslbClustersGeoTags="eu" --set ohmyglb.hostAlias.hostname="test-gslb-ns-eu.example.com" --set ohmyglb.hostAlias.ip="$(HOST_ALIAS_IP2)"
+deploy-second-ohmyglb: HELM_ARGS = --set ohmyglb.hostAlias.enabled=true --set ohmyglb.clusterGeoTag="us" --set ohmyglb.extGslbClustersGeoTags="eu" --set ohmyglb.hostAlias.hostname="test-gslb-ns-eu.example.com" --set ohmyglb.hostAlias.ip="$(HOST_ALIAS_IP2)" --set ohmyglb.image=$(OHMYGLB_IMAGE)
 deploy-second-ohmyglb: deploy-gslb-operator deploy-local-ingress
 
 .PHONY: deploy-full-local-setup
 deploy-full-local-setup: deploy-two-local-clusters
-	./deploy/full.sh deploy-test-apps
+	ADDITIONAL_TARGETS=deploy-test-apps ./deploy/full.sh
 
 .PHONY: destroy-full-local-setup
 destroy-full-local-setup: destroy-two-local-clusters

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 	go test -v ./pkg/controller/gslb/
 
 .PHONY: terratest
-terratest: test
+terratest:
 	cd terratest/test/ && go mod download && go test -v
 
 .PHONY: e2e-test

--- a/deploy/full.sh
+++ b/deploy/full.sh
@@ -1,15 +1,30 @@
 #!/bin/bash
+set -o errexit
+
 # Workaround of Make being to smart on up-to-date PHONY targets
 # If we execute all of them normal way, then targets from `deploy-second-ohmyglb`
 # will never be executed as they contain the same underlying target as `deploy-first-ohmyglb`
 # but with different variables
 
 NODE_ROLE=${NODE_ROLE:-worker}
+ADDITIONAL_TARGETS=${ADDITIONAL_TARGETS:-}
+TEST_CURRENT_COMMIT=${TEST_CURRENT_COMMIT:-}
+
+if [ "$TEST_CURRENT_COMMIT" == "yes" ]
+then
+    ./deploy/registry.sh
+    commit_hash=$(git rev-parse --short HEAD)
+    operator-sdk build ohmyglb:${commit_hash}
+    docker tag ohmyglb:${commit_hash} localhost:5000/ohmyglb:${commit_hash}
+    docker push localhost:5000/ohmyglb:${commit_hash}
+    export OHMYGLB_IMAGE=localhost:5000/ohmyglb:${commit_hash}
+fi
+
 make use-second-context
 export HOST_ALIAS_IP1=$(kubectl get nodes test-gslb2-${NODE_ROLE} -o custom-columns='IP:status.addresses[0].address' --no-headers)
-make use-first-context deploy-first-ohmyglb deploy-gslb-cr $1
+make use-first-context deploy-first-ohmyglb deploy-gslb-cr ${ADDITIONAL_TARGETS}
 export HOST_ALIAS_IP2=$(kubectl get nodes test-gslb1-${NODE_ROLE} -o custom-columns='IP:status.addresses[0].address' --no-headers)
-make use-second-context deploy-second-ohmyglb deploy-gslb-cr $1
+make use-second-context deploy-second-ohmyglb deploy-gslb-cr ${ADDITIONAL_TARGETS}
 
 make wait-for-nginx-ingress-ready
 make wait-for-gslb-ready

--- a/deploy/kind/cluster-terratest.yaml
+++ b/deploy/kind/cluster-terratest.yaml
@@ -1,5 +1,9 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+    endpoint = ["http://172.17.0.1:5000"]
 nodes:
 - role: control-plane
   extraPortMappings:

--- a/deploy/kind/cluster.yaml
+++ b/deploy/kind/cluster.yaml
@@ -1,5 +1,9 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+    endpoint = ["http://172.17.0.1:5000"]
 nodes:
 - role: control-plane
 - role: worker

--- a/deploy/kind/cluster2-terratest.yaml
+++ b/deploy/kind/cluster2-terratest.yaml
@@ -1,5 +1,9 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+    endpoint = ["http://172.17.0.1:5000"]
 nodes:
 - role: control-plane
   extraPortMappings:

--- a/deploy/kind/cluster2.yaml
+++ b/deploy/kind/cluster2.yaml
@@ -1,5 +1,9 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5000"]
+    endpoint = ["http://172.17.0.1:5000"]
 nodes:
 - role: control-plane
 - role: worker

--- a/deploy/registry.sh
+++ b/deploy/registry.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -o errexit
+
+# create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi


### PR DESCRIPTION
* Deploy ephemeral local registry-v2 as a container on the same network as kind
  clusters
* Build current HEAD and push to this local registry
* Configure kind clusters to consume local 'insecure' registry
* Can be enabled by `export TEST_CURRENT_COMMIT=yes`
* Deploys stable version by default
* Idea is based on https://kind.sigs.k8s.io/docs/user/local-registry/
* Enable current commit testing in terratest pipeline