### PR TITLE
Propagate Gslb CR annotations down to Gslb ingress

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -11,6 +11,6 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v2
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.2.0
         with:
           args: ./...

--- a/pkg/controller/gslb/gslb_controller_test.go
+++ b/pkg/controller/gslb/gslb_controller_test.go
@@ -500,6 +500,28 @@ func TestGslbController(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Can't setup env var: (%v)", err)
 		}
+
+	})
+
+	t.Run("Gslb properly propagates annotation down to Ingress", func(t *testing.T) {
+
+		expectedAnnotations := map[string]string{"annotation": "test"}
+		gslb.Annotations = expectedAnnotations
+		err = cl.Update(context.TODO(), gslb)
+		if err != nil {
+			t.Fatalf("Can't update gslb: (%v)", err)
+		}
+
+		reconcileAndUpdateGslb(t, r, req, cl, gslb)
+
+		err = cl.Get(context.TODO(), req.NamespacedName, ingress)
+		if err != nil {
+			t.Fatalf("Failed to get expected ingress: (%v)", err)
+		}
+
+		if !reflect.DeepEqual(ingress.Annotations, expectedAnnotations) {
+			t.Errorf("got:\n %s Gslb ingress annotations,\n\n want:\n %s", ingress.Annotations, expectedAnnotations)
+		}
 	})
 }
 

--- a/pkg/controller/gslb/ingress.go
+++ b/pkg/controller/gslb/ingress.go
@@ -15,8 +15,9 @@ import (
 func (r *ReconcileGslb) gslbIngress(gslb *ohmyglbv1beta1.Gslb) (*v1beta1.Ingress, error) {
 	ingress := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      gslb.Name,
-			Namespace: gslb.Namespace,
+			Name:        gslb.Name,
+			Namespace:   gslb.Namespace,
+			Annotations: gslb.Annotations,
 		},
 		Spec: gslb.Spec.Ingress,
 	}
@@ -56,8 +57,9 @@ func (r *ReconcileGslb) ensureIngress(request reconcile.Request,
 		return &reconcile.Result{}, err
 	}
 
-	// Update existing object with new spec
+	// Update existing object with new spec and annotations
 	found.Spec = i.Spec
+	found.Annotations = i.Annotations
 	err = r.client.Update(context.TODO(), found)
 
 	if err != nil {


### PR DESCRIPTION
* Main use case is TLS enabled ingress and cert-manager integration
* Resolves #113