### PR TITLE
Extend release pipeline with docker build and push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Operator image build and push
+        env:
+          OPERATOR_SDK_VERSION: v0.16.0
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          wget https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -O ./operator-sdk
+          chmod +x ./operator-sdk
+          export PATH=.:$PATH
+          docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
+          make build
+          make push
       - uses: dave-mcconnell/helm-gh-pages-microservices@master
         with:
           access-token: ${{ secrets.CR_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REPO ?= absaoss/ohmyglb
-VERSION ?= $$(operator-sdk run --local --operator-flags=-v)
+VERSION ?= $$(helm show chart chart/ohmyglb/|awk '/appVersion:/ {print $$2}')
 VALUES_YAML ?= chart/ohmyglb/values.yaml
 HELM_ARGS ?=
 ETCD_DEBUG_IMAGE ?= quay.io/coreos/etcd:v3.2.25

--- a/chart/ohmyglb/Chart.yaml
+++ b/chart/ohmyglb/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.5.6
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.5.6
+appVersion: 0.6.0
 
 dependencies:
   - name: coredns

--- a/chart/ohmyglb/values.yaml
+++ b/chart/ohmyglb/values.yaml
@@ -6,7 +6,7 @@ global:
   # - name: "image-pull-secret"
 
 ohmyglb:
-  image: absaoss/ohmyglb:v0.5.6
+  image: absaoss/ohmyglb:v0.6.0
   ingressNamespace: "ohmyglb"
   dnsZone: &dnsZone "cloud.example.com" # dnsZone controlled by gslb
   edgeDNSZone: &edgeDNSZone "example.com" # main zone which would contain gslb zone to delegate

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.5.6"
+	Version = "0.6.0"
 )


### PR DESCRIPTION
* Build and push using version for `version.go`
* Forgotten v0.6.0 version bump