### PR TITLE
Simplify versioning process

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -27,6 +27,7 @@ jobs:
           wget https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu -O ./operator-sdk
           chmod +x ./operator-sdk
           export PATH=.:$PATH
+          export VERSION=$(make version)
           ./deploy/full.sh
           kubectl get pods -A
           make use-second-context

--- a/chart/ohmyglb/templates/operator.yaml
+++ b/chart/ohmyglb/templates/operator.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: ohmyglb
   namespace: ohmyglb
+  labels:
+{{ include "chart.labels" . | indent 4  }}
 spec:
   replicas: 1
   selector:
@@ -22,7 +24,7 @@ spec:
       serviceAccountName: ohmyglb
       containers:
         - name: ohmyglb
-          image: {{ .Values.ohmyglb.image }}
+          image: {{ .Values.ohmyglb.imageRepo }}:{{ .Chart.AppVersion }}
           command:
           - ohmyglb
           imagePullPolicy: Always
@@ -35,6 +37,8 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "ohmyglb"
+            - name: OHMYGLB_VERSION
+              value: {{ quote .Chart.AppVersion }}
             - name: CLUSTER_GEO_TAG
               value: {{ quote .Values.ohmyglb.clusterGeoTag }}
             - name: EXT_GSLB_CLUSTERS_GEO_TAGS

--- a/chart/ohmyglb/values.yaml
+++ b/chart/ohmyglb/values.yaml
@@ -6,7 +6,7 @@ global:
   # - name: "image-pull-secret"
 
 ohmyglb:
-  image: absaoss/ohmyglb:v0.6.0
+  imageRepo: absaoss/ohmyglb # image tag is defined in Chart.AppVersion, see Chart.yaml
   ingressNamespace: "ohmyglb"
   dnsZone: &dnsZone "cloud.example.com" # dnsZone controlled by gslb
   edgeDNSZone: &edgeDNSZone "example.com" # main zone which would contain gslb zone to delegate

--- a/deploy/full.sh
+++ b/deploy/full.sh
@@ -17,7 +17,8 @@ then
     operator-sdk build ohmyglb:${commit_hash}
     docker tag ohmyglb:${commit_hash} localhost:5000/ohmyglb:${commit_hash}
     docker push localhost:5000/ohmyglb:${commit_hash}
-    export OHMYGLB_IMAGE=localhost:5000/ohmyglb:${commit_hash}
+    export OHMYGLB_IMAGE_REPO=localhost:5000/ohmyglb
+    sed -i "s/${VERSION}/${commit_hash}/g" chart/ohmyglb/Chart.yaml
 fi
 
 make use-second-context

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,7 @@
 package version
 
+import "os"
+
 var (
-	Version = "0.6.0"
+	Version = os.Getenv("OHMYGLB_VERSION")
 )


### PR DESCRIPTION
* Use appVersion in `Chart.yaml` as single source of truth
* `version.go` to rely on OHMYGLB_VERSION env var for version logging
* Associated make target and deployment script modifications