### PR TITLE
Switch to safe geotag propagation with depresolver

### DIFF
--- a/pkg/controller/gslb/gslb_controller_test.go
+++ b/pkg/controller/gslb/gslb_controller_test.go
@@ -626,6 +626,16 @@ func TestGslbController(t *testing.T) {
 		}
 	})
 
+	t.Run("Reflect GeoTag in the Status as unset by default", func(t *testing.T) {
+		reconcileAndUpdateGslb(t, r, req, cl, gslb)
+		got := gslb.Status.GeoTag
+		want := "unset"
+
+		if got != want {
+			t.Errorf("got: '%s' GeoTag status, want:'%s'", got, want)
+		}
+	})
+
 	t.Run("Reflect GeoTag in the Status", func(t *testing.T) {
 		defer func() {
 			err = os.Unsetenv("CLUSTER_GEO_TAG")

--- a/pkg/controller/gslb/gslb_controller_test.go
+++ b/pkg/controller/gslb/gslb_controller_test.go
@@ -648,6 +648,11 @@ func TestGslbController(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Can't setup env var: (%v)", err)
 		}
+		resolver := depresolver.NewDependencyResolver(context.TODO(), cl)
+		r.config, err = resolver.ResolveOperatorConfig()
+		if err != nil {
+			t.Fatalf("config error: (%v)", err)
+		}
 		reconcileAndUpdateGslb(t, r, req, cl, gslb)
 		got := gslb.Status.GeoTag
 		want := "eu"

--- a/pkg/controller/gslb/internal/depresolver/depresolver.go
+++ b/pkg/controller/gslb/internal/depresolver/depresolver.go
@@ -36,6 +36,7 @@ type DependencyResolver struct {
 const (
 	lessOrEqualToZeroErrorMessage = "\"%s is less or equal to zero\""
 	lessThanZeroErrorMessage      = "\"%s is less than zero\""
+	doesNotMatchRegexMessage      = "\"%s does not match /%s/ regexp rule\""
 )
 
 //NewDependencyResolver returns a new depresolver.DependencyResolver

--- a/pkg/controller/gslb/internal/depresolver/depresolver.go
+++ b/pkg/controller/gslb/internal/depresolver/depresolver.go
@@ -18,6 +18,8 @@ import (
 type Config struct {
 	//Reschedule of Reconcile loop to pickup external Gslb targets
 	ReconcileRequeueSeconds int
+	// Cluster Geo Tag to determine specific location
+	ClusterGeoTag string
 }
 
 //DependencyResolver resolves configuration for GSLB

--- a/pkg/controller/gslb/internal/depresolver/depresolver_config.go
+++ b/pkg/controller/gslb/internal/depresolver/depresolver_config.go
@@ -29,7 +29,7 @@ func (dr *DependencyResolver) validateConfig(config *Config) error {
 	if config.ReconcileRequeueSeconds <= 0 {
 		return fmt.Errorf(lessOrEqualToZeroErrorMessage, "ReconcileRequeueSeconds")
 	}
-	geoTagRegexString := "^[a-z]*[A-Z]*\\d*$"
+	geoTagRegexString := "^[a-zA-Z\\-\\d]*$"
 	geoTagRegex, _ := regexp.Compile(geoTagRegexString)
 	if !geoTagRegex.Match([]byte(config.ClusterGeoTag)) {
 		return fmt.Errorf(doesNotMatchRegexMessage, "ClusterGeoTag", geoTagRegexString)

--- a/pkg/controller/gslb/internal/depresolver/depresolver_config.go
+++ b/pkg/controller/gslb/internal/depresolver/depresolver_config.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	reconcileRequeueSecondsKey = "RECONCILE_REQUEUE_SECONDS"
+	clusterGeoTagKey           = "CLUSTER_GEO_TAG"
 )
 
 // ResolveOperatorConfig executes once. It reads operator's configuration
@@ -17,6 +18,7 @@ func (dr *DependencyResolver) ResolveOperatorConfig() (*Config, error) {
 		dr.config = &Config{}
 		// set predefined values when not read from the environment variables
 		dr.config.ReconcileRequeueSeconds, _ = env.GetEnvAsIntOrFallback(reconcileRequeueSecondsKey, 30)
+		dr.config.ClusterGeoTag = env.GetEnvAsStringOrFallback(clusterGeoTagKey, "unset")
 		dr.errorConfig = dr.validateConfig(dr.config)
 	})
 	return dr.config, dr.errorConfig

--- a/pkg/controller/gslb/internal/depresolver/depresolver_config.go
+++ b/pkg/controller/gslb/internal/depresolver/depresolver_config.go
@@ -2,6 +2,7 @@ package depresolver
 
 import (
 	"fmt"
+	"regexp"
 
 	"k8s.io/kubernetes/pkg/util/env"
 )
@@ -27,6 +28,11 @@ func (dr *DependencyResolver) ResolveOperatorConfig() (*Config, error) {
 func (dr *DependencyResolver) validateConfig(config *Config) error {
 	if config.ReconcileRequeueSeconds <= 0 {
 		return fmt.Errorf(lessOrEqualToZeroErrorMessage, "ReconcileRequeueSeconds")
+	}
+	geoTagRegexString := "^[a-z]*[A-Z]*\\d*$"
+	geoTagRegex, _ := regexp.Compile(geoTagRegexString)
+	if !geoTagRegex.Match([]byte(config.ClusterGeoTag)) {
+		return fmt.Errorf(doesNotMatchRegexMessage, "ClusterGeoTag", geoTagRegexString)
 	}
 	return nil
 }

--- a/pkg/controller/gslb/internal/depresolver/depresolver_test.go
+++ b/pkg/controller/gslb/internal/depresolver/depresolver_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-var defaultConfig = Config{30}
+var defaultConfig = Config{30, "unset"}
 
 func TestResolveSpecWithFilledFields(t *testing.T) {
 	//arrange
@@ -98,7 +98,7 @@ func TestResolveConfigWithOneValidEnv(t *testing.T) {
 	defer cleanup()
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
 	resolver := NewDependencyResolver(context.TODO(), cl)
-	expected := Config{50}
+	expected := Config{50, "unset"}
 	_ = os.Setenv(reconcileRequeueSecondsKey, strconv.Itoa(expected.ReconcileRequeueSeconds))
 	//act
 	config, err := resolver.ResolveOperatorConfig()

--- a/pkg/controller/gslb/internal/depresolver/depresolver_test.go
+++ b/pkg/controller/gslb/internal/depresolver/depresolver_test.go
@@ -194,6 +194,30 @@ func TestResolveConfigWithEmptyReconcileRequeueSecondsKey(t *testing.T) {
 	assert.Equal(t, defaultConfig, *config)
 }
 
+func TestResolveConfigWithMalformedGeoTag(t *testing.T) {
+	//arrange
+	defer cleanup()
+	_ = os.Setenv(clusterGeoTagKey, "i.am.wrong??.")
+	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
+	resolver := NewDependencyResolver(context.TODO(), cl)
+	//act
+	_, err := resolver.ResolveOperatorConfig()
+	//assert
+	assert.Error(t, err)
+}
+
+func TestResolveConfigWithProperGeoTag(t *testing.T) {
+	//arrange
+	defer cleanup()
+	_ = os.Setenv(clusterGeoTagKey, "eu")
+	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
+	resolver := NewDependencyResolver(context.TODO(), cl)
+	//act
+	_, err := resolver.ResolveOperatorConfig()
+	//assert
+	assert.NoError(t, err)
+}
+
 func TestConfigRunOnce(t *testing.T) {
 	//arrange
 	defer cleanup()
@@ -215,6 +239,9 @@ func TestConfigRunOnce(t *testing.T) {
 func cleanup() {
 	if os.Unsetenv(reconcileRequeueSecondsKey) != nil {
 		panic(fmt.Errorf("cleanup %s", reconcileRequeueSecondsKey))
+	}
+	if os.Unsetenv(clusterGeoTagKey) != nil {
+		panic(fmt.Errorf("cleanup %s", clusterGeoTagKey))
 	}
 }
 

--- a/pkg/controller/gslb/internal/depresolver/depresolver_test.go
+++ b/pkg/controller/gslb/internal/depresolver/depresolver_test.go
@@ -209,7 +209,7 @@ func TestResolveConfigWithMalformedGeoTag(t *testing.T) {
 func TestResolveConfigWithProperGeoTag(t *testing.T) {
 	//arrange
 	defer cleanup()
-	_ = os.Setenv(clusterGeoTagKey, "eu")
+	_ = os.Setenv(clusterGeoTagKey, "eu-west-1")
 	cl, _ := getTestContext("./testdata/filled_omitempty.yaml")
 	resolver := NewDependencyResolver(context.TODO(), cl)
 	//act

--- a/pkg/controller/gslb/status.go
+++ b/pkg/controller/gslb/status.go
@@ -2,7 +2,6 @@ package gslb
 
 import (
 	"context"
-	"os"
 	"regexp"
 
 	ohmyglbv1beta1 "github.com/AbsaOSS/ohmyglb/pkg/apis/ohmyglb/v1beta1"
@@ -31,7 +30,7 @@ func (r *ReconcileGslb) updateGslbStatus(gslb *ohmyglbv1beta1.Gslb) error {
 		return err
 	}
 
-	gslb.Status.GeoTag = os.Getenv("CLUSTER_GEO_TAG")
+	gslb.Status.GeoTag = r.config.ClusterGeoTag
 
 	err = r.updateHealthyRecordsMetric(gslb, gslb.Status.HealthyRecords)
 	if err != nil {


### PR DESCRIPTION
* Consistent cluster geo tag propagation with new deprespolver
* Should get rid us of `status.geoTag` required issues during upgrade
